### PR TITLE
Fix validation of unique elements inside mappings.

### DIFF
--- a/Authors.md
+++ b/Authors.md
@@ -1,6 +1,7 @@
 Code:
  * Grokzen (https://github.com/Grokzen)
  * Markbaas (https://github.com/markbaas)
+ * Gonditeniz (https://github.com/gonditeniz)
 
 Testing:
  * Glenn Schmottlach (https://github.com/gschmottlach-xse)

--- a/pykwalify/core.py
+++ b/pykwalify/core.py
@@ -248,9 +248,12 @@ class Core(object):
                         if val is None:
                             continue
                         if val in table:
-                            curr_path = "{}/{}/{}".format(path, j, k)
-                            prev_path = "{}/{}/{}".format(path, table[val], k)
-                            errors.append("value.notunique :: value: {} : {}".format(k, path))
+                            curr_path = "{}/{}/{}".format(path, j, v)
+                            prev_path = "{}/{}/{}".format(path, table[val], v)
+                            errors.append("value.notunique :: value: {} : {} : {}".format(val, curr_path, prev_path))
+                        else:
+                            table[val] = j
+                        j += 1
         elif r._unique:
             Log.debug("Found unique value in sequence")
             table = {}

--- a/tests/files/fail/9f.yaml
+++ b/tests/files/fail/9f.yaml
@@ -33,4 +33,5 @@ schema:
             - type: str
               unique: True
 errors:
+  - 'value.notunique :: value: bar : /2/name : /1/name'
   - 'value.notunique :: value: foo : /0/groups/3 : /0/groups/0'


### PR DESCRIPTION
Fix a problem I have found when validating unique values for elements inside mappings.

I give an example below of a schema and yaml file with duplicated values that previously was validating and now gives you an error because the value is not unique for *name*. I also provide the code I use to validate those files.

*Schema*
```yaml
type: seq 
required: yes 
sequence:
  - type: map 
    required: yes 
    mapping:
      "name": 
        type: str 
        required: yes 
        unique: yes 
      "description":
        type: str 
        required: yes 
```

*Example YAML*
```yaml
- name: name1
  description: description1
- name: name1
  description: description2
```
*Code*
```python
from pykwalify.core import Core
kwalify_core = Core(source_file='yamltest.yml', schema_files=['schematest.yml'])
kwalify_core.validate(raise_exception=True)
```

*Validation error*
```
<SchemaError: error code 2: validation.invalid : ['value.notunique :: value: name1 : /1/name : /0/name']>
```