### PR TITLE
Improve docs

### DIFF
--- a/ReleaseNotes.rst
+++ b/ReleaseNotes.rst
@@ -2,6 +2,13 @@
 Release Notes
 =============
 
+
+Next Release
+============
+
+- Improvements to documentation (scottclowe).
+
+
 1.5.0
 =====
 

--- a/ReleaseNotes.rst
+++ b/ReleaseNotes.rst
@@ -83,8 +83,11 @@ Next Release
 1.0.1
 =====
 
-Switched back to semantic version numbering for this lib. See *README.md* section *Important notes on version schema changes* on how to fix any issues with this change.
+Switched back to semantic version numbering for this lib.
 
+- After the release of `15.01` the version schema was changed back from the <year>.<month> style version schema back to semantic version names. One big problem with this change is that `pypi` can't handle the change back to semantic names very well and because of this I had to remove the old releases from pypi and replace it with a single version `1.0.1`.
+- No matter what version you were using you should consider upgrading to `1.0.1`. The difference between the two versions is very small and contains mostly bugfixes and added improvements.
+- The old releases can still be obtained from `github.com` and if you really need the old version you can add the download url to your `requirements.txt` file.
 
 
 15.01

--- a/docs/Authors.md
+++ b/docs/Authors.md
@@ -6,3 +6,7 @@ Code:
 
 Testing:
  * Glenn Schmottlach (https://github.com/gschmottlach-xse)
+
+Documentation:
+ * Grokzen (https://github.com/Grokzen)
+ * Scott Lowe (https://github.com/scottclowe)

--- a/docs/Extensions.md
+++ b/docs/Extensions.md
@@ -8,7 +8,7 @@ Extensions can be used to do more complex validation that is not supported by th
 
 ## Specifying what extensions to use.
 
-There is 2 ways to load extensions into a schema.
+There are 2 ways to load extensions into a schema.
 
 First you can specify any `*.py` file via the cli via the `-e FILE` or `--extension FILE` flag. If you would do this when using pykwalify as a library you should pass in a list of files to the `extensions` variable to the `Core` class.
 

--- a/docs/Upgrade Instructions.md
+++ b/docs/Upgrade Instructions.md
@@ -1,6 +1,7 @@
 # Upgrading instructions
 
-This document will describe any major changes that has been done to the existing API:s that can cause existing schemas to break. If new types was added it will not be described in here because it will not break existing schemas.
+This document describes all major changes to the API that could cause existing schemas to break.
+If new types were added, they will not be described here because it will not break existing schemas.
 
 
 ## 1.4.x --> 1.5.0
@@ -23,7 +24,7 @@ If you use `SchemaConflict` in your code, you must update to use the new `msg` a
 
 Almost all validation error messages have been updated. If you are dependent on the error messages that is located in the variable `c.validation_errors` you must check if your code must be updated to use the new error messages.
 
-If you are parsing the error messages yourself you now have access to the exceptions and more detailed variables containing the `msg`, `path`, `key`, `regex` and `value` for each validation error.
+When parsing the error messages yourself, you now have access to the exceptions and more detailed variables containing the `msg`, `path`, `key`, `regex` and `value` for each validation error.
 
 
 ## 1.1.0 --> 1.2.0

--- a/docs/Upgrade Instructions.md
+++ b/docs/Upgrade Instructions.md
@@ -5,12 +5,12 @@ This document will describe any major changes that has been done to the existing
 
 ## 1.4.x --> 1.5.0
 
-Regex recieved some fixes so make sure your schema files is still compatible and do not produce any new errors.
+Regex received some fixes, so make sure your schema files are still compatible and do not produce any new errors.
 
 
 ## 1.3.0 --> 1.4.0
 
-Python 3.2 support have been dropped. It was going to be dropped when python 3.5 was released but this make supporting python 2 & 3 at the same time easier now when fixing unicode support.
+Python 3.2 support has been dropped. It was going to be dropped when python 3.5 was released, but this made supporting python 2 & 3 at the same time easier now when fixing unicode support.
 
 All logging and exception messages have been fixed to work with unicode characters in schema and data files. If you use this in lib mode then you should test your code to ensure it is still compatible.
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -39,7 +39,9 @@ type: str
 
 ### sequence or seq
 
-Sequence of values. Specifying `type: seq` is optional when `sequence` or `seq` in found in the schema.
+Sequence of values.
+
+Specifying `type: seq` is optional when `sequence` or `seq` is present in the rule.
 
 #### Example:
 
@@ -60,10 +62,9 @@ Note: The following feature is considered experimental in release `1.2.0` and ab
 Multiple values are allowed in the `sequence` block. It can also be nested to any depth.
 
 The value `matching` has been introduced to the `sequence` block that can be set to either:
-
- - `any` this mean that one or more sequence blocks has to be valid for the value in the sequence to be valid.
- - `all` this mean that all sequence blocks has to be valid for each value to be valid.
- - `*` this mean that zero to all blocks has to be valid for each value to be valid.
+- `any` this mean that one or more sequence blocks has to be valid for the value in the sequence to be valid.
+- `all` this mean that all sequence blocks has to be valid for each value to be valid.
+- `*` this mean that zero to all blocks has to be valid for each value to be valid.
 
 ```yaml
 # Schema
@@ -85,7 +86,8 @@ sequence:
 ### mapping or map
 
 Mapping of values (dict).
-The map type is implicitly assumed when `mapping` or `map` is present in the rule of a schema.
+
+The map type is implicitly assumed when `mapping` or `map` is present in the rule.
 
 #### Example:
 
@@ -118,7 +120,9 @@ By default, map keys specified in the map rule can be omitted unless they have t
 
 ### timestamp
 
-Parse a string to determine if it is a valid timestamp. Parsing is done with `python-dateutil` lib and see all valid formats at https://dateutil.readthedocs.org/en/latest/examples.html#parse-examples.
+Parse a string to determine if it is a valid timestamp.
+
+Parsing is done with [dateutil](https://pypi.python.org/pypi/python-dateutil). You can see all valid formats in [the relevant dateutil documentation](https://dateutil.readthedocs.org/en/latest/examples.html#parse-examples).
 
 #### Example:
 
@@ -157,7 +161,9 @@ key_one: foobar
 
 ## enum
 
-Value must be one of the specified values. Currently only exact case matching is implemented. If you need complex validation you should use `pattern` (See next section)
+Set of possible elements; the value must be a member of this set.
+
+Currently only exact case matching is implemented. If you need complex validation you should use `pattern`.
 
 #### Example:
 
@@ -177,9 +183,11 @@ blood: AB
 
 ## pattern
 
-Specifies regular expression pattern of value. Uses `re.match()` internally. Pattern works on all scalar types.
+Specifies a regular expression pattern which the value must satisfy.
 
-Note: Pattern no longer works in map. Use `regex;(regex-pattern)` as keys in `mapping`
+Uses [re.match()](https://docs.python.org/3/library/re.html#re.match) internally. Pattern works for all scalar types.
+
+Note: For using regex to define possible key names in mapping, see `regex;(regex-pattern)` instead.
 
 #### Example:
 
@@ -239,7 +247,9 @@ age: 25
 
 ## name
 
-Name of schema. This have no effect on the parsing.
+Name of schema.
+
+This have no effect on the parsing, but is useful for humans to read.
 
 ```yaml
 # Schema
@@ -249,7 +259,9 @@ name: foobar schema
 
 ## desc
 
-Description is not used for validation. This have no effect on the parsing.
+Description of schema.
+
+This have no effect on the parsing, but is useful for humans to read.
 
 #### Example:
 
@@ -261,9 +273,9 @@ desc: This schema is very foobar
 
 ## unique [Default: `False`]
 
-The unique property can be set for sequences and mappings.
-
 If unique is set to `True`, then the sequence/mapping cannot contain any repeated entries.
+
+The unique constraint can only be set when the type is `sequence` or `map`.
 
 #### Example:
 
@@ -308,13 +320,13 @@ datasources:
 
 ## regex;(regex-pattern) or re;(regex-pattern)
 
-This is only implemented in *map* where a key inside the mapping keyword can implement this `regex;(regex-pattern)` pattern and all keys will be matched against the pattern.
+Only applies to *map*. This is only implemented in *map* where a key inside the mapping keyword can implement this `regex;(regex-pattern)` pattern and all keys will be matched against the pattern.
 
 Please note that the regex should be wrapped with `( )` and these parentheses will be removed at runtime.
 
-If a match is found then it will parsed the subrules on that key. A single key can be matched against multiple regex rules and the normal map rules.
+If a match is found then it will be parsed against the subrules on that key. A single key can be matched against multiple regex rules and the normal map rules.
 
-When defining a regex, `matching-rule` should always be set to configure the behaviour when using multiple regexes.
+When defining a regex key, `matching-rule` should also be set to configure the behaviour when using multiple regexes.
 
 #### Example:
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -286,7 +286,7 @@ sequence:
 
 Only applies to *map*.
 If `True`, the map can have keys which are not present in the schema, and these can map to anything.
-Any keys which _are_ specified in the schema must have values which conform to their corresponding rules, if they are present.
+Any keys which *are* specified in the schema must have values which conform to their corresponding constraints, if they are present.
 
 #### Example:
 
@@ -343,7 +343,7 @@ media: 1
 
 Only applies to *map*. This enables more finegrained control over how the matching rule should behave when validation regex keys inside mappings.
 
-Currently supported rules are:
+Currently supported constraint settings are:
 
  - `any` One or more of the regex must match.
  - `all` All defined regex must match each key.
@@ -413,7 +413,7 @@ schema;list_int:
 
 ## include
 
-Used in `partial schema` system. Includes is lazy loaded during parsing/validation.
+Used in `partial schema` system. Includes are lazy and are loaded during parsing/validation.
 
 #### Example:
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -37,11 +37,11 @@ type: str
 ```
 
 
-### sequence or seq
+### sequence
 
 Sequence of values.
 
-Specifying `type: seq` is optional when `sequence` or `seq` is present in the rule.
+The sequence type is implicitly assumed when `sequence` or its alias `seq` is present in the rule.
 
 #### Example:
 
@@ -83,11 +83,11 @@ sequence:
 ```
 
 
-### mapping or map
+### mapping
 
 Mapping of values (dict).
 
-The map type is implicitly assumed when `mapping` or `map` is present in the rule.
+The map type is implicitly assumed when `mapping` or its alias `map` is present in the rule.
 
 #### Example:
 
@@ -113,9 +113,9 @@ map:
 ```
 
 There are some constraints which are available only for the map type, and expand its functionality.
-See the `allowempty`, `regex;(regex-pattern)` and `matching-rule` sections below for details.
+See the [allowempty](#allowempty), [regex;(regex-pattern)](#regex;(regex-pattern)) and [matching-rule](#matching-rule) sections below for details.
 
-By default, map keys specified in the map rule can be omitted unless they have the `required` constraint explictly set to `True`.
+By default, map keys specified in the map rule can be omitted unless they have the [required](#required) constraint explictly set to `True`.
 
 
 ### timestamp
@@ -139,9 +139,11 @@ d1: "2015-03-29T18:45:00+00:00"
 ```
 
 
-## required or req [Default: `False`]
+## required
 
-Value is required when `True` (default is `False`). If the key is not present a validation error will be raised.
+If the `required` constraint is set to `True`, the key and its value must be present, otherwise a validation error will be raised.
+
+Default is `False`. Alias is `req`.
 
 #### Example:
 
@@ -163,7 +165,7 @@ key_one: foobar
 
 Set of possible elements; the value must be a member of this set.
 
-Currently only exact case matching is implemented. If you need complex validation you should use `pattern`.
+Currently only exact case matching is implemented. If you need complex validation you should use [pattern](#pattern).
 
 #### Example:
 
@@ -187,7 +189,7 @@ Specifies a regular expression pattern which the value must satisfy.
 
 Uses [re.match()](https://docs.python.org/3/library/re.html#re.match) internally. Pattern works for all scalar types.
 
-Note: For using regex to define possible key names in mapping, see `regex;(regex-pattern)` instead.
+Note: For using regex to define possible key names in mapping, see [regex;(regex-pattern)](#regex;(regex-pattern)) instead.
 
 #### Example:
 
@@ -219,7 +221,7 @@ For the data value (or length), `x`, the range can be specified to test for the 
 
 Non-numeric types require non-negative values for the boundaries, since length can not be negative.
 
-Types `bool` and `any` are not compatible with `range`.
+Types [bool](#type) and [any]](#type) are not compatible with `range`.
 
 #### Example:
 
@@ -271,11 +273,13 @@ desc: This schema is very foobar
 ```
 
 
-## unique [Default: `False`]
+## unique
 
 If unique is set to `True`, then the sequence/mapping cannot contain any repeated entries.
 
 The unique constraint can only be set when the type is `sequence` or `map`.
+
+Default is `False`.
 
 #### Example:
 
@@ -294,11 +298,13 @@ sequence:
 ```
 
 
-## allowempty [Default: `False`]
+## allowempty
 
 Only applies to *map*.
 If `True`, the map can have keys which are not present in the schema, and these can map to anything.
 Any keys which *are* specified in the schema must have values which conform to their corresponding constraints, if they are present.
+
+Default is `False`.
 
 #### Example:
 
@@ -318,15 +324,17 @@ datasources:
 ```
 
 
-## regex;(regex-pattern) or re;(regex-pattern)
+## regex;(regex-pattern)
 
-Only applies to *map*. This is only implemented in *map* where a key inside the mapping keyword can implement this `regex;(regex-pattern)` pattern and all keys will be matched against the pattern.
+Only applies to *map*. Alias is `re;(regex-pattern)`.
+
+This is only implemented in *map* where a key inside the mapping keyword can implement this `regex;(regex-pattern)` pattern and all keys will be matched against the pattern.
 
 Please note that the regex should be wrapped with `( )` and these parentheses will be removed at runtime.
 
 If a match is found then it will be parsed against the subrules on that key. A single key can be matched against multiple regex rules and the normal map rules.
 
-When defining a regex key, `matching-rule` should also be set to configure the behaviour when using multiple regexes.
+When defining a regex key, [matching-rule](#matching-rule) should also be set to configure the behaviour when using multiple regexes.
 
 #### Example:
 
@@ -351,14 +359,15 @@ media: 1
 ```
 
 
-## matching-rule [Default: `'any'`]
+## matching-rule
 
 Only applies to *map*. This enables more finegrained control over how the matching rule should behave when validation regex keys inside mappings.
 
 Currently supported constraint settings are:
-
  - `any` One or more of the regex must match.
  - `all` All defined regex must match each key.
+
+Default is `any`.
 
 #### Example:
 
@@ -390,7 +399,7 @@ It is possible to create small partial schemas that can be included in other sch
 
 To define a partial schema use the keyword `schema;(schema-id):`. `(schema-id)` must be globally unique for the loaded schema partials. If collisions is detected then error will be raised.
 
-To use a partial schema use the keyword `include: (schema-id):`. This will work at any place you can specify the keyword `type`. Include directive do not currently work inside a partial schema.
+To use a partial schema use the keyword `include: (schema-id):`. This will work at any place you can specify the keyword [type](#type). Include directive do not currently work inside a partial schema.
 
 It is possible to define any number of partial schemas in any schema file as long as they are defined at top level of the schema.
 
@@ -416,7 +425,7 @@ sequence:
 
 ## schema;(schema-name)
 
-See `Partial schemas` section for details.
+See the [Partial schemas](#partial-schemas) section for details.
 
 Names must be globally unique.
 
@@ -438,7 +447,7 @@ schema;list_int:
 
 ## include
 
-Used in `partial schema` system. Includes are lazy and are loaded during parsing/validation.
+Used in [partial schema](#partial-schemas) system. Includes are lazy and are loaded during parsing/validation.
 
 #### Example:
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -57,7 +57,7 @@ sequence:
 
 Note: The following feature is considered experimental in release `1.2.0` and above.
 
-Multiple values is allowed in the `sequence` block. It can also be nested to any depth.
+Multiple values are allowed in the `sequence` block. It can also be nested to any depth.
 
 A new value has been introduced to the `sequence` block `matching` that can be set to either:
 
@@ -103,7 +103,7 @@ map:
 
 ## required or req
 
-Value is required when true (Default is false). If the key is not present a validation error will be raised.
+Value is required when true (default is false). If the key is not present a validation error will be raised.
 
 Example:
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -274,7 +274,7 @@ sequence:
 
 ## allowempty [Default: `False`]
 
-Only applies to map.
+Only applies to *map*.
 If `True`, the map can have keys which are not present in the schema, and these can map to anything.
 Any keys which _are_ specified in the schema must have values which conform to their corresponding rules, if they are present.
 
@@ -298,7 +298,7 @@ datasources:
 
 ## regex;(regex-pattern) or re;(regex-pattern)
 
-This is only implemented in map where a key inside the mapping keyword can implement this `regex;(regex-pattern)` pattern and all keys will be matched against the pattern.
+This is only implemented in *map* where a key inside the mapping keyword can implement this `regex;(regex-pattern)` pattern and all keys will be matched against the pattern.
 
 Please note that the regex should be wrapped with `( )` and these parentheses will be removed at runtime.
 
@@ -331,7 +331,7 @@ media: 1
 
 ## matching-rule [Default: `'any'`]
 
-Only applies to map. This enables more finegrained control over how the matching rule should behave when validation regex keys inside mappings.
+Only applies to *map*. This enables more finegrained control over how the matching rule should behave when validation regex keys inside mappings.
 
 Currently supported rules are:
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -100,6 +100,10 @@ map:
   key_one:
     type: str
 ```
+```yaml
+# Data
+key_one: 'bar'
+```
 
 
 ### timestamp

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -9,9 +9,7 @@ This document will describe all implemented validation rules.
 
 Type of the value.
 
-The followings are available:
-
- - `any` (Will allways be true no matter what the value is, even non implemented types like `lambda` or `functions`)
+ - `any` (Will always be true no matter what the value is, even unimplemented types like `lambda` or `functions`)
  - `bool`
  - `date` [NYI]
  - `float`

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -117,7 +117,7 @@ d1: "2015-03-29T18:45:00+00:00"
 ```
 
 
-## required or req
+## required or req [Default: `false`]
 
 Value is required when true (default is false). If the key is not present a validation error will be raised.
 
@@ -237,7 +237,7 @@ desc: This schema is very foobar
 ```
 
 
-## unique
+## unique [Default: `false`]
 
 The unique property can be set for sequences and mappings.
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -350,11 +350,24 @@ Currently supported constraint settings are:
 
 #### Example:
 
+The following dataset will raise an error because the key `bar2` does not fit all of the regex.
+If the constraint was instead `matching-rule: all`, the same data would be valid because all the keys in the data match one of the regex formats and associated constraints in the schema.
+
 ```yaml
 # Schema
 type: map
-matching-rule: 'any'
-mapping: ...
+matching-rule: all
+mapping:
+  regex;([1-2]$):
+    type: int
+  regex;(^foobar):
+    type: int
+```
+```yaml
+# Data
+foobar1: 1
+foobar2: 2
+bar2: 3
 ```
 
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -30,7 +30,8 @@ Example:
 ```yaml
 # Schema
 type: str
-
+```
+```yaml
 # Data
 'Foobar'
 ```
@@ -47,7 +48,8 @@ Example:
 type: seq
 sequence:
   - type: str
-
+```
+```yaml
 # Data
 - 'Foobar'
 - 'Barfoo'
@@ -72,7 +74,8 @@ sequence:
   - type: seq
     sequence:
       - type: int
-
+```
+```yaml
 # Data
 - - 123
 - "foobar"
@@ -111,7 +114,8 @@ type: map
 mapping:
   d1:
     type: timestamp
-
+```
+```yaml
 # Data
 d1: "2015-03-29T18:45:00+00:00"
 ```
@@ -130,7 +134,8 @@ mapping:
   key_one:
     type: str
     required: True
-
+```
+```yaml
 # Data
 key_one: foobar
 ```
@@ -149,7 +154,8 @@ mapping:
   blood:
     type: str
     enum: ['A', 'B', 'O', 'AB']
-
+```
+```yaml
 # Data
 blood: AB
 ```
@@ -170,7 +176,8 @@ mapping:
   email:
     type: str
     pattern: .+@.+
-
+```
+```yaml
 # Data
 email: foo@mail.com
 ```
@@ -208,7 +215,8 @@ mapping:
     range:
       min: 18
       max-ex: 30
-
+```
+```yaml
 # Data
 password: foobar123
 age: 25
@@ -251,7 +259,8 @@ type: seq
 sequence:
   - type: str
     unique: True
-
+```
+```yaml
 # Data
 - users
 - foo
@@ -301,7 +310,8 @@ mapping:
       - type: str
   regex;(me.+):
     type: number
-
+```
+```yaml
 # Data
 mic:
   - foo
@@ -321,7 +331,8 @@ mapping:
   datasources:
     type: map
     allowempty: True
-
+```
+```yaml
 # Data
 datasources:
   test1: test1.py
@@ -353,7 +364,8 @@ schema;map_str:
 type: seq
 sequence:
   - include: map_str
-
+```
+```yaml
 # Data
 - foo: opa
 ```

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -99,6 +99,24 @@ map:
 ```
 
 
+### timestamp
+
+Parse a string to determine if it is a valid timestamp. Parsing is done with `python-dateutil` lib and see all valid formats at `https://dateutil.readthedocs.org/en/latest/examples.html#parse-examples`.
+
+Example:
+
+```yaml
+# Schema
+type: map
+mapping:
+  d1:
+    type: timestamp
+
+# Data
+d1: "2015-03-29T18:45:00+00:00"
+```
+
+
 ## required or req
 
 Value is required when true (default is false). If the key is not present a validation error will be raised.
@@ -158,57 +176,6 @@ email: foo@mail.com
 ```
 
 
-## regex;(regex-pattern) or re;(regex-pattern)
-
-This is only implemented in map where a key inside the mapping keyword can implement this `regex;(regex-pattern)` pattern and all keys will be matched against the pattern.
-
-Please note that the regex should be wrapped with `( )`and they will be removed during runtime.
-
-If a match is found then it will parsed the subrules on that key. A single key can be matched against multiple regex rules and the normal map rules.
-
-When defining a regex, `matching-rule` should allways be set to configure the behaviour when using multiple regex:s.
-
-Example:
-
-```yaml
-# Schema
-type: map
-matching-rule: 'any'
-mapping:
-  regex;(mi.+):
-    type: seq
-    sequence:
-      - type: str
-  regex;(me.+):
-    type: number
-
-# Data
-mic:
-  - foo
-  - bar
-media: 1
-```
-
-
-## matching-rule [Default: any]
-
-Only applies to map. This enables more finegrained control over how the matching rule should behave when validation regex keys inside mappings.
-
-Currently supported rules is
-
- - `any` One or more of the regex must match.
- - `all` All defined regex must match each key.
-
-Example:
-
-```yaml
-# Schema
-type: map
-matching-rule: 'any'
-mapping: ...
-```
-
-
 ## range
 
 Range of value between `min` or `min-ex` and `max` or `max-ex`.
@@ -248,28 +215,6 @@ age: 25
 ```
 
 
-## unique
-
-The unique property can be set for sequences and mappings.
-
-If unique is set to `true`, then the sequence/mapping cannot contain any repeated entries.
-
-Example:
-
-```yaml
-# Schema
-type: seq
-sequence:
-  - type: str
-    unique: True
-
-# Data
-- users
-- foo
-- admin
-```
-
-
 ## name
 
 Name of schema. This have no effect on the parsing.
@@ -292,21 +237,76 @@ desc: This schema is very foobar
 ```
 
 
-## timestamp
+## unique
 
-Parse a string to determine if it is a valid timestamp. Parsing is done with `python-dateutil` lib and see all valid formats at `https://dateutil.readthedocs.org/en/latest/examples.html#parse-examples`.
+The unique property can be set for sequences and mappings.
+
+If unique is set to `true`, then the sequence/mapping cannot contain any repeated entries.
+
+Example:
+
+```yaml
+# Schema
+type: seq
+sequence:
+  - type: str
+    unique: True
+
+# Data
+- users
+- foo
+- admin
+```
+
+
+## matching-rule [Default: `any`]
+
+Only applies to map. This enables more finegrained control over how the matching rule should behave when validation regex keys inside mappings.
+
+Currently supported rules are:
+
+ - `any` One or more of the regex must match.
+ - `all` All defined regex must match each key.
 
 Example:
 
 ```yaml
 # Schema
 type: map
+matching-rule: 'any'
+mapping: ...
+```
+
+
+## regex;(regex-pattern) or re;(regex-pattern)
+
+This is only implemented in map where a key inside the mapping keyword can implement this `regex;(regex-pattern)` pattern and all keys will be matched against the pattern.
+
+Please note that the regex should be wrapped with `( )` and these parentheses will be removed at runtime.
+
+If a match is found then it will parsed the subrules on that key. A single key can be matched against multiple regex rules and the normal map rules.
+
+When defining a regex, `matching-rule` should always be set to configure the behaviour when using multiple regexes.
+
+Example:
+
+```yaml
+# Schema
+type: map
+matching-rule: 'any'
 mapping:
-  d1:
-    type: timestamp
+  regex;(mi.+):
+    type: seq
+    sequence:
+      - type: str
+  regex;(me.+):
+    type: number
 
 # Data
-d1: "2015-03-29T18:45:00+00:00"
+mic:
+  - foo
+  - bar
+media: 1
 ```
 
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -316,7 +316,7 @@ sequence:
 
 ## allowempty
 
-Only applies to *map*.
+Only applies to [mapping](#mapping).
 If `True`, the map can have keys which are not present in the schema, and these can map to anything.
 Any keys which *are* specified in the schema must have values which conform to their corresponding constraints, if they are present.
 
@@ -342,9 +342,9 @@ datasources:
 
 ## regex;(regex-pattern)
 
-Only applies to *map*. Alias is `re;(regex-pattern)`.
+Only applies to [mapping](#mapping). Alias is `re;(regex-pattern)`.
 
-This is only implemented in *map* where a key inside the mapping keyword can implement this `regex;(regex-pattern)` pattern and all keys will be matched against the pattern.
+This is only implemented in [mapping](#mapping) where a key inside the mapping keyword can implement this `regex;(regex-pattern)` pattern and all keys will be matched against the pattern.
 
 Please note that the regex should be wrapped with `( )` and these parentheses will be removed at runtime.
 
@@ -377,7 +377,7 @@ media: 1
 
 ## matching-rule
 
-Only applies to *map*. This enables more finegrained control over how the matching rule should behave when validation regex keys inside mappings.
+Only applies to [mapping](#mapping). This enables more finegrained control over how the matching rule should behave when validation regex keys inside mappings.
 
 Currently supported constraint settings are:
  - `any` One or more of the regex must match.

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -25,7 +25,7 @@ The following types are available:
  
 [NYI] means Not Yet Implemented
 
-Example:
+#### Example:
 
 ```yaml
 # Schema
@@ -41,7 +41,7 @@ type: str
 
 Sequence of values. Specifying `type: seq` is optional when `sequence` or `seq` in found in the schema.
 
-Example:
+#### Example:
 
 ```yaml
 # Schema
@@ -86,7 +86,7 @@ sequence:
 
 Mapping of values (dict). Specifying `type: map` is optional when `mapping` or `map` is found in the schema.
 
-Example:
+#### Example:
 
 ```yaml
 # Schema
@@ -110,7 +110,7 @@ key_one: 'bar'
 
 Parse a string to determine if it is a valid timestamp. Parsing is done with `python-dateutil` lib and see all valid formats at https://dateutil.readthedocs.org/en/latest/examples.html#parse-examples.
 
-Example:
+#### Example:
 
 ```yaml
 # Schema
@@ -129,7 +129,7 @@ d1: "2015-03-29T18:45:00+00:00"
 
 Value is required when true (default is false). If the key is not present a validation error will be raised.
 
-Example:
+#### Example:
 
 ```yaml
 # Schema
@@ -149,7 +149,7 @@ key_one: foobar
 
 Value must be one of the specified values. Currently only exact case matching is implemented. If you need complex validation you should use `pattern` (See next section)
 
-Example:
+#### Example:
 
 ```yaml
 # Schema
@@ -171,7 +171,7 @@ Specifies regular expression pattern of value. Uses `re.match()` internally. Pat
 
 Note: Pattern no longer works in map. Use `regex;(regex-pattern)` as keys in `mapping`
 
-Example:
+#### Example:
 
 ```yaml
 # Schema
@@ -203,7 +203,7 @@ Non-numeric types require non-negative values for the boundaries, since length c
 
 Types `bool` and `any` are not compatible with `range`.
 
-Example:
+#### Example:
 
 ```yaml
 # Schema
@@ -241,7 +241,7 @@ name: foobar schema
 
 Description is not used for validation. This have no effect on the parsing.
 
-Example:
+#### Example:
 
 ```yaml
 # Schema
@@ -255,7 +255,7 @@ The unique property can be set for sequences and mappings.
 
 If unique is set to `true`, then the sequence/mapping cannot contain any repeated entries.
 
-Example:
+#### Example:
 
 ```yaml
 # Schema
@@ -278,7 +278,7 @@ Only applies to map.
 If `True`, the map can have keys which are not present in the schema, and these can map to anything.
 Any keys which _are_ specified in the schema must have values which conform to their corresponding rules, if they are present.
 
-Example:
+#### Example:
 
 ```yaml
 # Schema
@@ -306,7 +306,7 @@ If a match is found then it will parsed the subrules on that key. A single key c
 
 When defining a regex, `matching-rule` should always be set to configure the behaviour when using multiple regexes.
 
-Example:
+#### Example:
 
 ```yaml
 # Schema
@@ -338,7 +338,7 @@ Currently supported rules are:
  - `any` One or more of the regex must match.
  - `all` All defined regex must match each key.
 
-Example:
+#### Example:
 
 ```yaml
 # Schema
@@ -385,7 +385,7 @@ See `Partial schemas` section for details.
 
 Names must be globally unique.
 
-Example:
+#### Example:
 
 ```yaml
 # Schema
@@ -405,7 +405,7 @@ schema;list_int:
 
 Used in `partial schema` system. Includes is lazy loaded during parsing/validation.
 
-Example:
+#### Example:
 
 ```yaml
 # Schema file one

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -234,17 +234,17 @@ mapping:
   password:
     type: str
     range:
-      max: 16
       min: 8
+      max: 16
   age:
     type: int
     range:
-      max-ex: 19
-      min-ex: 18
+      min: 18
+      max-ex: 30
 
 # Data
-password: xxx123
-age: 15
+password: foobar123
+age: 25
 ```
 
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -272,9 +272,13 @@ sequence:
 ```
 
 
-## allowempty
+## allowempty [Default: `false`]
 
-Only applies to map. It enables a dict to have items in it that is not validated. It can be combined with mapping to check for some fixed properties but still validate if any random properties exists.
+Only applies to map.
+If `True`, the map can have keys which are not present in the schema, and these can map to anything.
+Any keys which _are_ specified in the schema must have values which conform to their corresponding rules, if they are present.
+
+Example:
 
 ```yaml
 # Schema

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -174,25 +174,21 @@ Example:
 
 ```yaml
 # Schema
-type: seq
-sequence:
-  - type: map
-    matching-rule: 'any'
-    mapping:
-      regex;(mi.+):
-        type: seq
-        sequence:
-          - type: str
-      regex;(me.+):
-        type: number
+type: map
+matching-rule: 'any'
+mapping:
+  regex;(mi.+):
+    type: seq
+    sequence:
+      - type: str
+  regex;(me.+):
+    type: number
 
 # Data
-- mic:
-  - input
-    foo
-  - output
-    bar
-- media: 1
+mic:
+  - foo
+  - bar
+media: 1
 ```
 
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -36,7 +36,7 @@ type: str
 ```
 
 
-## sequence or seq
+### sequence or seq
 
 Sequence of values. Specifying `type: seq` is optional when `sequence` or `seq` in found in the schema.
 
@@ -79,7 +79,7 @@ sequence:
 ```
 
 
-## mapping or map
+### mapping or map
 
 Mapping of values (dict). Specifying `type: map` is optional when `mapping` or `map` is found in the schema.
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -125,9 +125,9 @@ d1: "2015-03-29T18:45:00+00:00"
 ```
 
 
-## required or req [Default: `false`]
+## required or req [Default: `False`]
 
-Value is required when true (default is false). If the key is not present a validation error will be raised.
+Value is required when `True` (default is `False`). If the key is not present a validation error will be raised.
 
 #### Example:
 
@@ -249,11 +249,11 @@ desc: This schema is very foobar
 ```
 
 
-## unique [Default: `false`]
+## unique [Default: `False`]
 
 The unique property can be set for sequences and mappings.
 
-If unique is set to `true`, then the sequence/mapping cannot contain any repeated entries.
+If unique is set to `True`, then the sequence/mapping cannot contain any repeated entries.
 
 #### Example:
 
@@ -272,7 +272,7 @@ sequence:
 ```
 
 
-## allowempty [Default: `false`]
+## allowempty [Default: `False`]
 
 Only applies to map.
 If `True`, the map can have keys which are not present in the schema, and these can map to anything.
@@ -329,7 +329,7 @@ media: 1
 ```
 
 
-## matching-rule [Default: `any`]
+## matching-rule [Default: `'any'`]
 
 Only applies to map. This enables more finegrained control over how the matching rule should behave when validation regex keys inside mappings.
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -1,13 +1,11 @@
 # Implemented validation rules
 
-This document will describe all implemented validation rules.
-
-[NYI] means Not Yet Implemented
+This document describes all implemented validation rules.
 
 
 ## type
 
-Type of the value.
+The following types are available:
 
  - `any` (Will always be true no matter what the value is, even unimplemented types like `lambda` or `functions`)
  - `bool`
@@ -24,6 +22,8 @@ Type of the value.
  - `text` (`str` or `number`)
  - `time` [NYI]
  - `timestamp`
+ 
+[NYI] means Not Yet Implemented
 
 Example:
 
@@ -57,7 +57,7 @@ Note: The following feature is considered experimental in release `1.2.0` and ab
 
 Multiple values are allowed in the `sequence` block. It can also be nested to any depth.
 
-A new value has been introduced to the `sequence` block `matching` that can be set to either:
+The value `matching` has been introduced to the `sequence` block that can be set to either:
 
  - `any` this mean that one or more sequence blocks has to be valid for the value in the sequence to be valid.
  - `all` this mean that all sequence blocks has to be valid for each value to be valid.
@@ -249,7 +249,9 @@ age: 15
 
 ## unique
 
-Value is unique for mapping or sequence.
+The unique property can be set for sequences and mappings.
+
+If unique is set to `true`, then the sequence/mapping cannot contain any repeated entries.
 
 Example:
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -25,7 +25,7 @@ The following types are available:
  
 [NYI] means Not Yet Implemented
 
-#### Example:
+##### Example
 
 ```yaml
 # Schema
@@ -43,7 +43,7 @@ Sequence of values (list).
 
 The sequence type is implicitly assumed when `sequence` or its alias `seq` is present in the rule.
 
-#### Example:
+##### Example
 
 ```yaml
 # Schema
@@ -67,7 +67,7 @@ The `matching` constraint can be used when the type is `sequence` to control how
 - `all` each list item must satisfy every subrule
 - `*` at least one list item must satisfy at least one subrule
 
-#### Example:
+##### Example
 
 This data file satisfies the following schema.
 
@@ -105,7 +105,7 @@ Mapping of values (dict).
 
 The map type is implicitly assumed when `mapping` or its alias `map` is present in the rule.
 
-#### Example:
+##### Example
 
 ```yaml
 # Schema
@@ -140,7 +140,7 @@ Parse a string to determine if it is a valid timestamp.
 
 Parsing is done with [dateutil](https://pypi.python.org/pypi/python-dateutil). You can see all valid formats in [the relevant dateutil documentation](https://dateutil.readthedocs.org/en/latest/examples.html#parse-examples).
 
-#### Example:
+##### Example
 
 ```yaml
 # Schema
@@ -161,7 +161,7 @@ If the `required` constraint is set to `True`, the key and its value must be pre
 
 Default is `False`. Alias is `req`.
 
-#### Example:
+##### Example
 
 ```yaml
 # Schema
@@ -183,7 +183,7 @@ Set of possible elements; the value must be a member of this set.
 
 Currently only exact case matching is implemented. If you need complex validation you should use [pattern](#pattern).
 
-#### Example:
+##### Example
 
 ```yaml
 # Schema
@@ -207,7 +207,7 @@ Uses [re.match()](https://docs.python.org/3/library/re.html#re.match) internally
 
 Note: For using regex to define possible key names in mapping, see [regex;(regex-pattern)](#regex;(regex-pattern)) instead.
 
-#### Example:
+##### Example
 
 ```yaml
 # Schema
@@ -239,7 +239,7 @@ Non-numeric types require non-negative values for the boundaries, since length c
 
 Types [bool](#type) and [any]](#type) are not compatible with `range`.
 
-#### Example:
+##### Example
 
 ```yaml
 # Schema
@@ -281,7 +281,7 @@ Description of schema.
 
 This have no effect on the parsing, but is useful for humans to read.
 
-#### Example:
+##### Example
 
 ```yaml
 # Schema
@@ -297,7 +297,7 @@ The unique constraint can only be set when the type is `sequence` or `map`.
 
 Default is `False`.
 
-#### Example:
+##### Example
 
 ```yaml
 # Schema
@@ -322,7 +322,7 @@ Any keys which *are* specified in the schema must have values which conform to t
 
 Default is `False`.
 
-#### Example:
+##### Example
 
 ```yaml
 # Schema
@@ -352,7 +352,7 @@ If a match is found then it will be parsed against the subrules on that key. A s
 
 When defining a regex key, [matching-rule](#matching-rule) should also be set to configure the behaviour when using multiple regexes.
 
-#### Example:
+##### Example
 
 ```yaml
 # Schema
@@ -385,7 +385,7 @@ Currently supported constraint settings are:
 
 Default is `any`.
 
-#### Example:
+##### Example
 
 The following dataset will raise an error because the key `bar2` does not fit all of the regex.
 If the constraint was instead `matching-rule: all`, the same data would be valid because all the keys in the data match one of the regex formats and associated constraints in the schema.
@@ -445,7 +445,7 @@ See the [Partial schemas](#partial-schemas) section for details.
 
 Names must be globally unique.
 
-#### Example:
+##### Example
 
 ```yaml
 # Schema
@@ -465,7 +465,7 @@ schema;list_int:
 
 Used in [partial schema](#partial-schemas) system. Includes are lazy and are loaded during parsing/validation.
 
-#### Example:
+##### Example
 
 ```yaml
 # Schema file one

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -101,7 +101,7 @@ map:
 
 ### timestamp
 
-Parse a string to determine if it is a valid timestamp. Parsing is done with `python-dateutil` lib and see all valid formats at `https://dateutil.readthedocs.org/en/latest/examples.html#parse-examples`.
+Parse a string to determine if it is a valid timestamp. Parsing is done with `python-dateutil` lib and see all valid formats at https://dateutil.readthedocs.org/en/latest/examples.html#parse-examples.
 
 Example:
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -39,7 +39,7 @@ type: str
 
 ### sequence
 
-Sequence of values.
+Sequence of values (list).
 
 The sequence type is implicitly assumed when `sequence` or its alias `seq` is present in the rule.
 
@@ -57,14 +57,19 @@ sequence:
 - 'Barfoo'
 ```
 
-Note: The following feature is considered experimental in release `1.2.0` and above.
+#### matching
 
-Multiple values are allowed in the `sequence` block. It can also be nested to any depth.
+Multiple subrules can be used within the `sequence` block. It can also be nested to any depth, with subrules constraining list items to be sequences of sequences.
 
-The value `matching` has been introduced to the `sequence` block that can be set to either:
-- `any` this mean that one or more sequence blocks has to be valid for the value in the sequence to be valid.
-- `all` this mean that all sequence blocks has to be valid for each value to be valid.
-- `*` this mean that zero to all blocks has to be valid for each value to be valid.
+The `matching` constraint can be used when the type is `sequence` to control how the parser handles a list of different subrules for the `sequence` block.
+
+- `any` each list item must satisfy at least one subrules
+- `all` each list item must satisfy every subrule
+- `*` at least one list item must satisfy at least one subrule
+
+#### Example:
+
+This data file satisfies the following schema.
 
 ```yaml
 # Schema
@@ -80,6 +85,17 @@ sequence:
 # Data
 - - 123
 - "foobar"
+```
+
+This schema file can never be satisfied, since items cannot both be strings and integers.
+
+```yaml
+# Schema
+type: seq
+matching: all
+sequence:
+  - type: str
+  - type: int
 ```
 
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -84,7 +84,8 @@ sequence:
 
 ### mapping or map
 
-Mapping of values (dict). Specifying `type: map` is optional when `mapping` or `map` is found in the schema.
+Mapping of values (dict).
+The map type is implicitly assumed when `mapping` or `map` is present in the rule of a schema.
 
 #### Example:
 
@@ -94,16 +95,25 @@ type: map
 mapping:
   key_one:
     type: str
-
-# This is also valid
-map:
-  key_one:
-    type: str
 ```
 ```yaml
 # Data
 key_one: 'bar'
 ```
+
+The schema below sets the map type implicitly, and is also a valid schema.
+
+```
+# Schema
+map:
+  key_one:
+    type: str
+```
+
+There are some constraints which are available only for the map type, and expand its functionality.
+See the `allowempty`, `regex;(regex-pattern)` and `matching-rule` sections below for details.
+
+By default, map keys specified in the map rule can be omitted unless they have the `required` constraint explictly set to `True`.
 
 
 ### timestamp

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -121,7 +121,7 @@ key_one: 'bar'
 
 The schema below sets the map type implicitly, and is also a valid schema.
 
-```
+```yaml
 # Schema
 map:
   key_one:

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -211,18 +211,19 @@ mapping: ...
 
 ## range
 
-Range of value between ``max / max-ex`` and ``min / min-ex``.
+Range of value between `min` or `min-ex` and `max` or `max-ex`.
 
- - `max` means `max-inclusive`. (a >= b)
- - `min` means `min-inclusive`. (a <= b)
- - `max-ex` means `max-exclusive`. (a > b)
- - `min-ex` means `min-exclusive`. (a < b)
+For numeric types (`int`, `float` and `number`), the value must be within the specified range, and for non-numeric types (`map`, `seq` and `str`) the length of the dict/list/string as given by `len()` must be within the range.
 
-This works with `map` `seq` `str` `int` `float` `number`. When used on non number types it will use `len()` on the value.
+For the data value (or length), `x`, the range can be specified to test for the following:
+ - `min` provides an inclusive lower bound, `a <= x`
+ - `max` provides an inclusive upper bound, `x <= b`
+ - `min-ex` provides an exclusive lower bound, `a < x`
+ - `max-ex` provieds an exclusive upper bound, `x < b`
 
-Type bool and any are not available with range.
+Non-numeric types require non-negative values for the boundaries, since length can not be negative.
 
-Non number types require non negative values for the boundaries.
+Types `bool` and `any` are not compatible with `range`.
 
 Example:
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -272,22 +272,23 @@ sequence:
 ```
 
 
-## matching-rule [Default: `any`]
+## allowempty
 
-Only applies to map. This enables more finegrained control over how the matching rule should behave when validation regex keys inside mappings.
-
-Currently supported rules are:
-
- - `any` One or more of the regex must match.
- - `all` All defined regex must match each key.
-
-Example:
+Only applies to map. It enables a dict to have items in it that is not validated. It can be combined with mapping to check for some fixed properties but still validate if any random properties exists.
 
 ```yaml
 # Schema
 type: map
-matching-rule: 'any'
-mapping: ...
+mapping:
+  datasources:
+    type: map
+    allowempty: True
+```
+```yaml
+# Data
+datasources:
+  test1: test1.py
+  test2: test2.py
 ```
 
 
@@ -324,23 +325,22 @@ media: 1
 ```
 
 
-## allowempty
+## matching-rule [Default: `any`]
 
-Only applies to map. It enables a dict to have items in it that is not validated. It can be combined with mapping to check for some fixed properties but still validate if any random properties exists.
+Only applies to map. This enables more finegrained control over how the matching rule should behave when validation regex keys inside mappings.
+
+Currently supported rules are:
+
+ - `any` One or more of the regex must match.
+ - `all` All defined regex must match each key.
+
+Example:
 
 ```yaml
 # Schema
 type: map
-mapping:
-  datasources:
-    type: map
-    allowempty: True
-```
-```yaml
-# Data
-datasources:
-  test1: test1.py
-  test2: test2.py
+matching-rule: 'any'
+mapping: ...
 ```
 
 
@@ -373,7 +373,6 @@ sequence:
 # Data
 - foo: opa
 ```
-
 
 
 ## schema;(schema-name)

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -184,9 +184,7 @@ sequence:
         sequence:
           - type: str
       regex;(me.+):
-        type: seq
-        sequence:
-          - type: bool
+        type: number
 
 # Data
 - mic:
@@ -195,8 +193,6 @@ sequence:
   - output
     bar
 - media: 1
-- foobar:
-    opa: True
 ```
 
 


### PR DESCRIPTION
I was trying and failing to get a `regex;(regex-pattern)` mapping key to work in my schema, so I had a look at the documentation and tried the `regex;(regex-pattern)` example on its own, and that didn't work either. So I decided to fix the documentation to have a working example here.

When doing this I got a little carried away and started making other improvements to the documentation, including some spelling and grammar corrections, and changes to the ordering of sections in the Validation Rules file.

Hope this is all okay!