### PR TITLE
Pattern validation, can't encode Int value

### DIFF
--- a/pykwalify/core.py
+++ b/pykwalify/core.py
@@ -558,7 +558,7 @@ class Core(object):
                 errors.append(SchemaError.SchemaErrorEntry(
                     msg=u"Value '{value}' does not match pattern '{pattern}'. Path: '{path}'",
                     path=path,
-                    value=nativestr(value),
+                    value=nativestr(str(value)),
                     pattern=rule._pattern))
 
         if rule._range is not None:


### PR DESCRIPTION
In case with:
```
   "netmask":
     type: str
     pattern: '\b((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(\.|$)){4}\b'
```

and yaml:

```
  - address:
      address:
      gateway:
      netmask: 0
```

I have an error:
```
  File "...pykwalify/core.py", line 212, in _validate
    self._validate_scalar(value, rule, path, errors, done=None)
  File "...pykwalify/core.py", line 561, in _validate_scalar
    value=nativestr(value),
  File "...pykwalify/compat.py", line 10, in nativestr
    return x if isinstance(x, str) else x.encode('utf-8', 'replace')
AttributeError: 'int' object has no attribute 'encode'
```