### PR TITLE
fix when the number of -v option is greater than 5 

### DIFF
--- a/pykwalify/__init__.py
+++ b/pykwalify/__init__.py
@@ -26,7 +26,7 @@ def init_logging(log_level):
     """
     Init logging settings with default set to INFO
     """
-    l = log_level_to_string_map[log_level]
+    l = log_level_to_string_map[min(log_level, 5)]
 
     msg = "%(levelname)s - %(name)s:%(lineno)s - %(message)s" if l in os.environ else "%(levelname)s - %(message)s"
 


### PR DESCRIPTION
-v option can be accumulated to increase the verbosity of the output.
but if number of v option is greater than 5 a KeyError is raised
