### PR TITLE
Do not fix dependencies version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,9 @@ setup(
         ],
     },
     install_requires=[
-        'docopt==0.6.2',
-        'PyYAML==3.11',
-        'python-dateutil==2.4.2',
+        'docopt>=0.6.2',
+        'PyYAML>=3.11',
+        'python-dateutil>=2.4.2',
     ],
     classifiers=(
         # 'Development Status :: 1 - Planning',


### PR DESCRIPTION
pyyaml released few days ago a new minor release, namely 3.12. As Pykwalify explicitely relies on 3.11, this means that many projects could not benefit from the new version. Moreover, as pip isn't bundled with a dependency contraints solver for ``-r``, this means that any requirements.txt that specify pyyaml and pykwalify (in this order) will not be satisfied (because pyyaml will be first installed in 3.12, then pykwalify will require 3.11, which is naturally in conflict with 3.12).