### PR TITLE
Allow mixed regex and normal keywords

### DIFF
--- a/pykwalify/core.py
+++ b/pykwalify/core.py
@@ -478,7 +478,11 @@ class Core(object):
             regex_mappings = [(regex_rule, re.search(regex_rule.map_regex_rule, str(k))) for regex_rule in rule.regex_mappings]
             log.debug(u" + Mapping Regex matches: %s", regex_mappings)
 
-            if any(regex_mappings):
+            if r is not None and not r.schema:
+                # validate recursively
+                log.debug(u" + Core Map: validate recursively: %s", r)
+                self._validate(v, r, u"{}/{}".format(path, k), done)
+            elif any(regex_mappings):
                 sub_regex_result = []
 
                 # Found at least one that matches a mapping regex
@@ -515,20 +519,15 @@ class Core(object):
                             regex="' and '".join(sorted([mm[0].map_regex_rule for mm in regex_mappings]))))
                 else:
                     log.debug(u" + No mapping rule defined")
-            elif r is None:
+            elif r is not None and r.schema:
+                print(u" + Something is ignored Oo : {}".format(r))
+            else:
                 if not rule.allowempty_map:
                     self.errors.append(SchemaError.SchemaErrorEntry(
                         msg=u"Key '{key}' was not defined. Path: '{path}'",
                         path=path,
                         value=value,
                         key=k))
-            else:
-                if not r.schema:
-                    # validate recursively
-                    log.debug(u" + Core Map: validate recursively: %s", r)
-                    self._validate(v, r, u"{}/{}".format(path, k), done)
-                else:
-                    print(u" + Something is ignored Oo : {}".format(r))
 
     def _validate_scalar(self, value, rule, path, done=None):
         log.debug(u"Validate scalar")

--- a/tests/files/success/38s.yaml
+++ b/tests/files/success/38s.yaml
@@ -1,0 +1,19 @@
+data:
+  standard:
+    FRIST-800-53
+  AU-1:
+    family: AU
+    name: Audit and Accountability Policy and Procedures
+schema:
+  type: map
+  mapping:
+    regex;/[A-Z]-/:
+      type: map
+      mapping:
+        name:
+          type: str
+        family:
+          type: str
+          required: yes
+    standard:
+      type: str

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -367,6 +367,8 @@ class TestCore(object):
             "36s.yaml",
             # Test keyword regex declared matching-rule all
             "37s.yaml",
+            # Test mixed keyword regex and normal keyword
+            "38s.yaml",
         ]
 
         _fail_tests = [


### PR DESCRIPTION
This patch reorders the order of checks in _validate_mapping so that explicit non-regex keywords are checked before regex keywords. This allows you to mix regex and normal keywords in schemas, with non-regex keywords being matched in preference.

Checked with pytest; all tests pass.
