### PR TITLE
schema["type"] should allow str or unicode, and the error now prints the type

### DIFF
--- a/pykwalify/rule.py
+++ b/pykwalify/rule.py
@@ -380,9 +380,9 @@ class Rule(object):
                     t = DEFAULT_TYPE
                     self.type = t
             else:
-                if not isinstance(schema["type"], str):
+                if not (isinstance(schema["type"], str) or isinstance(schema["type"], unicode)):
                     raise RuleError(
-                        msg=u"Key 'type' in schema rule is not a string type",
+                        msg=u"Key 'type' in schema rule is not a string type (found "+str(type(schema["type"]))+")",
                         error_key=u"type.not_string",
                         path=path,
                     )

--- a/pykwalify/rule.py
+++ b/pykwalify/rule.py
@@ -15,6 +15,7 @@ from pykwalify.types import (
     is_builtin_type,
     is_collection_type,
     is_number,
+    is_string,
     mapping_aliases,
     sequence_aliases,
     type_class,
@@ -380,9 +381,9 @@ class Rule(object):
                     t = DEFAULT_TYPE
                     self.type = t
             else:
-                if not isinstance(schema["type"], (str, int)):
+                if not is_string(schema["type"]):
                     raise RuleError(
-                        msg=u"Key 'type' in schema rule is not a string type (found " + str(type(schema["type"])) + ")",
+                        msg=u"Key 'type' in schema rule is not a string type (found %s)" % type(schema["type"]).__name__,
                         error_key=u"type.not_string",
                         path=path,
                     )
@@ -448,7 +449,7 @@ class Rule(object):
     def init_format_value(self, v, rule, path):
         log.debug(u"Init format value : %s", path)
 
-        if isinstance(v, basestring):
+        if is_string(v):
             self._format = [v]
         elif isinstance(v, list):
             valid = True
@@ -491,7 +492,7 @@ class Rule(object):
     def init_example(self, v, rule, path):
         log.debug(u'Init example value : {0}'.format(path))
 
-        if not isinstance(v, basestring):
+        if not is_string(v):
             raise RuleError(
                 msg=u"Value: {0} for keyword example must be a string".format(v),
                 error_key=u"example.not_string",
@@ -636,7 +637,7 @@ class Rule(object):
     def init_func(self, v, rule, path):
         """
         """
-        if not isinstance(v, str):
+        if not is_string(v):
             raise RuleError(
                 msg=u"Value: {0} for func keyword must be a string".format(v),
                 error_key=u"func.notstring",
@@ -725,7 +726,7 @@ class Rule(object):
         """
         log.debug(u"Init name value : %s", path)
 
-        if not isinstance(v, basestring):
+        if not is_string(v):
             raise RuleError(
                 msg=u"Value: {0} for keyword name must be a string".format(v),
                 error_key=u"name.not_string",
@@ -739,7 +740,7 @@ class Rule(object):
         """
         log.debug(u"Init descr value : %s", path)
 
-        if not isinstance(v, basestring):
+        if not is_string(v):
             raise RuleError(
                 msg=u"Value: {0} for keyword desc must be a string".format(v),
                 error_key=u"desc.not_string",
@@ -753,7 +754,7 @@ class Rule(object):
         """
         log.debug(u"Init required value : %s", path)
 
-        if not isinstance(v, bool):
+        if not is_bool(v):
             raise RuleError(
                 msg=u"Value: '{0}' for required keyword must be a boolean".format(v),
                 error_key=u"required.not_bool",
@@ -766,7 +767,7 @@ class Rule(object):
         """
         log.debug(u"Init pattern value : %s", path)
 
-        if not isinstance(v, str):
+        if not is_string(v):
             raise RuleError(
                 msg=u"Value of pattern keyword: '{0}' is not a string".format(v),
                 error_key=u"pattern.not_string",
@@ -836,7 +837,7 @@ class Rule(object):
         """
         log.debug(u"Init assert value : %s", path)
 
-        if not isinstance(v, str):
+        if not is_string(v):
             raise RuleError(
                 msg=u"Value: '{0}' for keyword 'assert' is not a string".format(v),
                 error_key=u"assert.not_str",
@@ -992,7 +993,7 @@ class Rule(object):
         """
         log.debug(u"Init ident value : %s", path)
 
-        if v is None or not isinstance(v, bool):
+        if v is None or not is_bool(v):
             raise RuleError(
                 msg=u"Value: '{0}' of 'ident' is not a boolean value".format(v),
                 error_key=u"ident.not_bool",
@@ -1028,7 +1029,7 @@ class Rule(object):
         """
         log.debug(u"Init unique value : %s", path)
 
-        if not isinstance(v, bool):
+        if not is_bool(v):
             raise RuleError(
                 msg=u"Value: '{0}' for 'unique' keyword is not boolean".format(v),
                 error_key=u"unique.not_bool",

--- a/pykwalify/rule.py
+++ b/pykwalify/rule.py
@@ -380,9 +380,9 @@ class Rule(object):
                     t = DEFAULT_TYPE
                     self.type = t
             else:
-                if not (isinstance(schema["type"], str) or isinstance(schema["type"], unicode)):
+                if not isinstance(schema["type"], (str, int)):
                     raise RuleError(
-                        msg=u"Key 'type' in schema rule is not a string type (found "+str(type(schema["type"]))+")",
+                        msg=u"Key 'type' in schema rule is not a string type (found " + str(type(schema["type"])) + ")",
                         error_key=u"type.not_string",
                         path=path,
                     )

--- a/pykwalify/types.py
+++ b/pykwalify/types.py
@@ -10,7 +10,6 @@ DEFAULT_TYPE = "str"
 
 _types = {
     "str": str,
-    "unicode": unicode,
     "int": int,
     "float": float,
     "number": None,

--- a/pykwalify/types.py
+++ b/pykwalify/types.py
@@ -10,6 +10,7 @@ DEFAULT_TYPE = "str"
 
 _types = {
     "str": str,
+    "unicode": unicode,
     "int": int,
     "float": float,
     "number": None,

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -55,13 +55,13 @@ class TestRule(unittest.TestCase):
         # Test that type key must be string otherwise exception is raised
         with pytest.raises(RuleError) as r:
             Rule(schema={"type": 1})
-        assert str(r.value) == "<RuleError: error code 4: Key 'type' in schema rule is not a string type: Path: '/'>"
+        assert str(r.value) == "<RuleError: error code 4: Key 'type' in schema rule is not a string type (found int): Path: '/'>"
         assert r.value.error_key == 'type.not_string'
 
         # this tests that the type key must be a string
         with pytest.raises(RuleError) as r:
             Rule(schema={"type": 1}, parent=None)
-        assert str(r.value) == "<RuleError: error code 4: Key 'type' in schema rule is not a string type: Path: '/'>"
+        assert str(r.value) == "<RuleError: error code 4: Key 'type' in schema rule is not a string type (found int): Path: '/'>"
         assert r.value.error_key == 'type.not_string'
 
     def test_name_value(self):


### PR DESCRIPTION
A fix for a frustrating bug I encountered. I'm surprised the unit tests even work.