### PR TITLE
changes print statement to log.debug()

### DIFF
--- a/pykwalify/core.py
+++ b/pykwalify/core.py
@@ -792,7 +792,7 @@ class Core(object):
         if isinstance(date_value, str):
             # If a date_format is specefied then use strptime on all formats
             # If no date_format is specefied then use dateutils.parse() to test the value
-            print(date_formats)
+            log.debug(date_formats)
             if date_formats:
                 # Run through all date_formats and it is valid if atleast one of them passed time.strptime() parsing
                 valid = False


### PR DESCRIPTION
When using a `type: date`, the `format` string was being output on `STDOUT`. It has been changed to a `log.debug()` to prevent undesired output.