### PR TITLE
use yaml.safe_load instead of load

### DIFF
--- a/pykwalify/core.py
+++ b/pykwalify/core.py
@@ -73,7 +73,7 @@ class Core(object):
                         raise CoreError(u"Unable to load any data from source json file")
                 elif source_file.endswith(".yaml") or source_file.endswith('.yml'):
                     try:
-                        self.source = yaml.load(stream)
+                        self.source = yaml.safe_load(stream)
                     except Exception:
                         raise CoreError(u"Unable to load any data from source yaml file")
                 else:
@@ -96,7 +96,7 @@ class Core(object):
                         except Exception:
                             raise CoreError(u"No data loaded from file : {0}".format(f))
                     elif f.endswith(".yaml") or f.endswith(".yml"):
-                        data = yaml.load(stream)
+                        data = yaml.safe_load(stream)
                         if not data:
                             raise CoreError(u"No data loaded from file : {0}".format(f))
                     else:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -502,7 +502,7 @@ class TestCore(object):
         for passing_test_file in pass_tests:
             f = self.f(os.path.join("success", passing_test_file))
             with open(f, "r") as stream:
-                yaml_data = yaml.load_all(stream)
+                yaml_data = yaml.safe_load_all(stream)
 
                 for document_index, document in enumerate(yaml_data):
                     data = document["data"]
@@ -523,7 +523,7 @@ class TestCore(object):
         for failing_test, exception_type in _fail_tests:
             f = self.f(os.path.join("fail", failing_test))
             with open(f, "r") as stream:
-                yaml_data = yaml.load_all(stream)
+                yaml_data = yaml.safe_load_all(stream)
 
                 for document_index, document in enumerate(yaml_data):
                     data = document["data"]

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -65,7 +65,7 @@ class TestUnicode(object):
             f = self.f(passing_test_files)
 
             with open(f, "r") as stream:
-                yaml_data = yaml.load(stream)
+                yaml_data = yaml.safe_load(stream)
                 data = yaml_data["data"]
                 schema = yaml_data["schema"]
 
@@ -120,7 +120,7 @@ class TestUnicode(object):
             f = self.f(failing_test)
 
             with open(f, "r") as stream:
-                yaml_data = yaml.load(stream)
+                yaml_data = yaml.safe_load(stream)
                 data = yaml_data["data"]
                 schema = yaml_data["schema"]
                 errors = yaml_data["errors"]


### PR DESCRIPTION
Fix #103 by replacing all calls to `load` by `safe_load`. This exists
for both ruamel and PyYAML.