### PR TITLE
core: don't catch exception for parse fail

### DIFF
--- a/pykwalify/core.py
+++ b/pykwalify/core.py
@@ -67,15 +67,9 @@ class Core(object):
 
             with open(source_file, "r") as stream:
                 if source_file.endswith(".json"):
-                    try:
-                        self.source = json.load(stream)
-                    except Exception:
-                        raise CoreError(u"Unable to load any data from source json file")
+                    self.source = json.load(stream)
                 elif source_file.endswith(".yaml") or source_file.endswith('.yml'):
-                    try:
-                        self.source = yaml.load(stream)
-                    except Exception:
-                        raise CoreError(u"Unable to load any data from source yaml file")
+                    self.source = yaml.load(stream)
                 else:
                     raise CoreError(u"Unable to load source_file. Unknown file format of specified file path: {0}".format(source_file))
 
@@ -91,10 +85,7 @@ class Core(object):
 
                 with open(f, "r") as stream:
                     if f.endswith(".json"):
-                        try:
-                            data = json.load(stream)
-                        except Exception:
-                            raise CoreError(u"No data loaded from file : {0}".format(f))
+                        data = json.load(stream)
                     elif f.endswith(".yaml") or f.endswith(".yml"):
                         data = yaml.load(stream)
                         if not data:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -121,9 +121,12 @@ class TestCore(object):
         schema_f = tmpdir.join("bar.json")
         schema_f.write("")
 
-        with pytest.raises(CoreError) as ex:
+        with pytest.raises(ValueError) as ex:
             Core(source_file=str(source_f), schema_files=[str(schema_f)])
-        assert "Unable to load any data from source json file" in str(ex.value)
+        # Python 2.7 and Python 3.5 JSON parsers return different exception
+        # strings for the same data file, so check for both errors strings.
+        assert ("No JSON object could be decoded" in str(ex.value) or
+                "Expecting value:" in str(ex.value))
 
         # Load empty schema files
         source_f = tmpdir.join("foo.json")
@@ -132,9 +135,10 @@ class TestCore(object):
         schema_f = tmpdir.join("bar.json")
         schema_f.write("")
 
-        with pytest.raises(CoreError) as ex:
+        with pytest.raises(ValueError) as ex:
             Core(source_file=str(source_f), schema_files=[str(schema_f)])
-        assert "No data loaded from file" in str(ex.value)
+        assert ("No JSON object could be decoded" in str(ex.value) or
+                "Expecting value:" in str(ex.value))
 
     def test_load_empty_yaml_file(self, tmpdir):
         """


### PR DESCRIPTION
When JSON/YAML parsing fails, you currently get a cryptic error
indicating pykwalify was unable to load the file. It is much more
helpful to see the actual parse error so that you can easily fix it. So,
just let the exception through rather than swallowing it.