### PR TITLE
Implement acceptance of custom file extensions for files to validate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ cleantox:
 	-rm -rf .tox/
 
 cleancov:
-	coverage combine
 	coverage erase
 	-rm -rf htmlcov/
 
@@ -39,7 +38,8 @@ cleanall: clean cleanegg cleanpy cleancov
 test:
 	coverage erase
 	coverage run --source pykwalify/ -m pytest
-	coverage report -m
+	coverage report
+	coverage html
 
 sdist:
 	python setup.py sdist

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ cleanall: clean cleanegg cleanpy cleancov
 
 test:
 	coverage erase
-	coverage run --source pykwalify/ -m python py.test
+	coverage run --source pykwalify/ -m pytest
+	coverage report -m
 
 sdist:
 	python setup.py sdist

--- a/pykwalify/cli.py
+++ b/pykwalify/cli.py
@@ -21,7 +21,7 @@ def parse_cli():
     #
 
     __docopt__ = """
-Usage: pykwalifire -d FILE -s FILE ... [-e FILE ...]
+Usage: pykwalify -d FILE -s FILE ... [-e FILE ...]
        [-y EXT] [-j EXT]
        [--strict-rule-validation] [--fix-ruby-style-regex]
        [--allow-assertions]
@@ -105,6 +105,6 @@ def cli_entrypoint():
     # Check minimum version of Python
     if sys.version_info < (2, 7, 0):
         sys.stderr.write(
-            u"WARNING: pykwalifire should be run with Python >= 2.7!\n\n")
+            u"WARNING: pykwalify should be run with Python >= 2.7!\n\n")
 
     run(parse_cli())

--- a/pykwalify/cli.py
+++ b/pykwalify/cli.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-""" pyKwalify - cli.py """
-
 # python std lib
 import logging
 import logging.config
@@ -25,24 +21,40 @@ def parse_cli():
     #
 
     __docopt__ = """
-usage: pykwalify -d FILE -s FILE ... [-e FILE ...]
-       [--strict-rule-validation] [--fix-ruby-style-regex] [--allow-assertions] [-v ...] [-q]
+Usage: pykwalifire -d FILE -s FILE ... [-e FILE ...]
+       [-y EXT] [-j EXT]
+       [--strict-rule-validation] [--fix-ruby-style-regex]
+       [--allow-assertions]
+       [-v ...] [-q]
 
-optional arguments:
-  -d FILE, --data-file FILE            the file to be tested
-  -e FILE, --extension FILE            file containing python extension
-  -s FILE, --schema-file FILE          schema definition file
-  --fix-ruby-style-regex               This flag fixes some of the quirks of ruby style regex
-                                       that is not compatible with python style regex
-  --strict-rule-validation             enables strict validation of all keywords for all
-                                       Rule objects to find unsupported keyword usage
-  --allow-assertions                   By default assertions is disabled due to security risk.
-                                       Error will be raised if assertion is used in schema
-                                       but this flag is not used. This option enables assert keyword.
-  -h, --help                           show this help message and exit
-  -q, --quiet                          suppress terminal output
-  -v, --verbose                        verbose terminal output (multiple -v increases verbosity)
-  --version                            display the version number and exit
+Options:
+  -d FILE, --data-file FILE            The file to be validated
+  -e FILE, --extension FILE            File containing python extension
+  -s FILE, --schema-file FILE          Schema definition file
+  -y EXT, --yaml-extension EXT         A custom YAML file extension to
+                                           accept for validation
+  -j EXT, --json-extension EXT         A custom JSON file extension to
+                                           accept for validation
+  --fix-ruby-style-regex               This flag fixes some of the
+                                           quirks of ruby style regex
+                                           that is not compatible with
+                                           python style regex
+  --strict-rule-validation             Enables strict validation of all
+                                           keywords for all Rule objects
+                                           to find unsupported keyword
+                                           usage
+  --allow-assertions                   By default assertions is disabled
+                                           due to security risk. An
+                                           error will be raised if
+                                           assertion is used in schema
+                                           but this flag is not used.
+                                           This option enables assert
+                                           keyword.
+  -h, --help                           Show this help message and exit
+  -q, --quiet                          Suppress terminal output
+  -v, --verbose                        Verbose terminal output (multiple
+                                           'v' increase verbosity)
+  --version                            Display the version number and exit
 """
 
     # Import pykwalify package
@@ -78,6 +90,8 @@ def run(cli_args):
         strict_rule_validation=cli_args['--strict-rule-validation'],
         fix_ruby_style_regex=cli_args['--fix-ruby-style-regex'],
         allow_assertions=cli_args['--allow-assertions'],
+        custom_yaml_ext=cli_args['--yaml-extension'],
+        custom_json_ext=cli_args['--json-extension'],
     )
     c.validate()
     return c
@@ -90,6 +104,7 @@ def cli_entrypoint():
     """
     # Check minimum version of Python
     if sys.version_info < (2, 7, 0):
-        sys.stderr.write(u"WARNING: pykwalify: It is recommended to run pykwalify on python version 2.7.x or later...\n\n")
+        sys.stderr.write(
+            u"WARNING: pykwalifire should be run with Python >= 2.7!\n\n")
 
     run(parse_cli())

--- a/tests/files/cli/1a.yext
+++ b/tests/files/cli/1a.yext
@@ -1,0 +1,3 @@
+- foo
+- bar
+- baz

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,36 @@ class TestCLI(object):
             assert k in cli_args
             assert cli_args[k] == expected[k]
 
+    def test_cli_custom_yaml_ext(self, tmpdir):
+        """
+        Test that when passing in certain arguments from commandline they
+        are handled correctly by docopt and correct args structure is returned.
+        """
+        input = tmpdir.join("cli/1a.yext")
+        schema_file = tmpdir.join("cli/1b.yaml")
+
+        sys.argv = [
+            'scripts/pykwalify',
+            '-d', str(input),
+            '-s', str(schema_file),
+            '-y', 'yext',
+            '-v'
+        ]
+
+        expected = {
+            '--data-file': str(input),
+            '--schema-file': [str(schema_file)],
+            '--quiet': False,
+            '--verbose': 1,
+            '--yaml-extension': 'yext',
+        }
+
+        cli_args = cli.parse_cli()
+
+        for k, v in expected.items():
+            assert k in cli_args
+            assert cli_args[k] == expected[k]
+
     def f(self, *args):
         """
         Returns abs path to test files inside tests/files/

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -136,7 +136,6 @@ class TestCore(object):
         Core(source_file=str(source_f), schema_files=[str(schema_f)],
              custom_json_ext='jext')
 
-
     def test_load_empty_json_file(self, tmpdir):
         """
         Loading an empty json files should raise an exception

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -110,6 +110,33 @@ class TestCore(object):
             Core(schema_files=[str(schema_f)])
         assert "Unknown file format. Supported file endings is" in str(ex.value)
 
+    def test_load_custom_yaml_format(self, tmpdir):
+        """
+        Try to load some file extension with custom support.
+        """
+        source_f = tmpdir.join("foo.yext")
+        source_f.write("3.14159")
+
+        schema_f = tmpdir.join("bar.yaml")
+        schema_f.write("type: float")
+
+        Core(source_file=str(source_f), schema_files=[str(schema_f)],
+             custom_yaml_ext='yext')
+
+    def test_load_custom_json_format(self, tmpdir):
+        """
+        Load source & schema files that has json file ending.
+        """
+        source_f = tmpdir.join("bar.jext")
+        source_f.write("3.14159")
+
+        schema_f = tmpdir.join("foo.json")
+        schema_f.write('{"type": "float"}')
+
+        Core(source_file=str(source_f), schema_files=[str(schema_f)],
+             custom_json_ext='jext')
+
+
     def test_load_empty_json_file(self, tmpdir):
         """
         Loading an empty json files should raise an exception


### PR DESCRIPTION
This pull request adds the following cli options:

- `-y EXT, --yaml-extension EXT`
- `-j EXT, --json-extension EXT`

Both accept a string representing a file extension for files like, e.g., `my-data-file.ext` which contain JSON or YAML data respectively, but don't share the default file endings.

Usage examples:

    pykwalify -d my-json-data-file.jext -s schema.yml -j jext
    pykwalify -d my-yaml-data-file.yext -s schema.yml -y yext
