### PR TITLE
Package the license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include docs/license.rst
 include docs/release-notes.rst
 include setup.py
 include README.md
+include LICENSE
 global-exclude __pycache__/*
 recursive-include tests *
 recursive-exclude tests *.py[co]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
+[metadata]
+license_file = LICENSE
+
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
Make sure the license file is included in Python packages.