### PR TITLE
Allow class as a keyword

### DIFF
--- a/pykwalify/rule.py
+++ b/pykwalify/rule.py
@@ -315,6 +315,7 @@ class Rule(object):
             ('allowempty_map', 'allowempty_map'),
             ('assertion', 'assertion'),
             ('default', 'default'),
+            ('class', 'class'),
             ('desc', 'desc'),
             ('enum', 'enum'),
             ('example', 'example'),
@@ -398,6 +399,7 @@ class Rule(object):
         func_mapping = {
             "allowempty": self.init_allow_empty_map,
             "assert": self.init_assert_value,
+            "class": lambda x, y, z: (),
             "default": self.init_default_value,
             "desc": self.init_desc_value,
             "enum": self.init_enum_value,
@@ -1185,6 +1187,7 @@ class Rule(object):
         All supported keywords:
          - allowempty_map
          - assertion
+         - class
          - date
          - default
          - desc
@@ -1221,7 +1224,7 @@ class Rule(object):
             'float': global_keywords + ['default', 'enum', 'range', 'required'],
             'number': global_keywords + ['default', 'enum'],
             'bool': global_keywords + ['default', 'enum'],
-            'map': global_keywords + ['allowempty_map', 'mapping', 'map', 'allowempty', 'required', 'matching-rule', 'range'],
+            'map': global_keywords + ['allowempty_map', 'mapping', 'map', 'allowempty', 'required', 'matching-rule', 'range', 'class'],
             'seq': global_keywords + ['sequence', 'seq', 'required', 'range', 'matching'],
             'sequence': global_keywords + ['sequence', 'seq', 'required'],
             'mapping': global_keywords + ['mapping', 'seq', 'required'],


### PR DESCRIPTION
This PR adds allows the class keyword to be included in schemas so that valid kwalify schema also works with pykwalify. Note that it does not actually do anything with them, it just allows them to be included.