### PR TITLE
Test release versions for python 3.5 & 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-  - "3.5-dev"
-  - "3.6-dev"
+  - "3.6"
   - "nightly"
 
 install: 


### PR DESCRIPTION
I'd like to look into the failing builds for 3.5 and 3.6, so this PR is currently just a stub