### PR TITLE
Display formatted long_description on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     version="1.6.1",
     description='Python lib/cli for JSON/YAML schema validation',
     long_description=readme + '\n\n' + history,
+    long_description_content_type='text/markdown',
     author="Johan Andersson",
     author_email="Grokzen@gmail.com",
     maintainer='Johan Andersson',


### PR DESCRIPTION
Set `long_description_content_type` to markdown

See pykwalify on PyPI: https://pypi.org/project/pykwalify/ Long description currently looks like:

> ![screenshot from 2018-05-09 10-09-04](https://user-images.githubusercontent.com/1117703/39819295-11157a38-5371-11e8-91bd-621ce125c5c7.png)

Will not take effect until next release