### PR TITLE
Allow custom functions to return exceptions

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -28,7 +28,7 @@ Each function defined inside the extension must be defined with a globally uniqu
     def method_name(value, rule_obj, path):
         pass
 
-To raise a validation error you can either raise any exception and it will propegate up to the caller or you can return ``True`` or ``False``. Any value/object that will be interpreted as ``False`` inside a if check will cause a ``CoreError`` validation error to be raised.
+To raise a validation error, you can either raise any exception (which will propagate up to the caller), or you can return ``True`` or ``False``. Any value/object interpreted as ``False`` inside an if check will cause a ``CoreError`` validation error to be raised.
 
 When using a validation function on a ``sequence``, the method will be called with the entire list content as the value.
 

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -28,7 +28,7 @@ Each function defined inside the extension must be defined with a globally uniqu
     def method_name(value, rule_obj, path):
         pass
 
-To raise a validation error, you can either raise any exception (which will propagate up to the caller), or you can return ``True`` or ``False``. Any value/object interpreted as ``False`` inside an if check will cause a ``CoreError`` validation error to be raised.
+To raise a validation error, you can either raise any exception (which will propagate up to the caller), or you can return ``True`` or ``False``. Any value/object interpreted as ``False`` inside an if check will cause a ``CoreError`` validation error to be raised. If you return anything other than ``True`` or ``False``, the return value will be interpreted as as string using the ``unicode()`` function and formatted as a parse error in the list of errors given at the end of the schema check.
 
 When using a validation function on a ``sequence``, the method will be called with the entire list content as the value.
 

--- a/pykwalify/core.py
+++ b/pykwalify/core.py
@@ -257,6 +257,12 @@ class Core(object):
 
                 # No exception will should be caught. If one is raised it should bubble up all the way.
                 ret = method(value, rule, path)
+                if ret is not True and ret is not None:
+                    msg = '%s. Path: {path}' % unicode(ret)
+                    self.errors.append(SchemaError.SchemaErrorEntry(
+                                    msg=msg,
+                                    path=path,
+                                    value=None))
 
                 # If False or None or some other object that is interpreted as False
                 if not ret:


### PR DESCRIPTION
Currently, custom functions can signal a schema failure only by raising
an exception. This means that instead of seeing a nice readout of all
schema failures in a list (as you normally would), you see an immediate
failure of just one exception with a stack trace. In addition, it is up
to the error message how much detail to provide, so sometimes you don't
have enough information to easily fix the issue.

Improve this by allowing custom functions to return an object that can
be turned into a string (can call str() or unicode() on it) instead of
raising an exception. The returned string will be collected in the list
of errors and displayed at the end, along with path information, in the
same way as the standard errors are displayed.