### PR TITLE
Small fixes to regex rule

### DIFF
--- a/pykwalify/core.py
+++ b/pykwalify/core.py
@@ -575,7 +575,7 @@ class Core(object):
             if not is_regex_rule:
                 is_present = k in value
             else:
-                is_present = any([re.search(required_regex, v) for v in value])
+                is_present = any([re.search(required_regex, str(v)) for v in value])
 
             # Specifying =: as key is considered the "default" if no other keys match
             if rr.required and not is_present and k != "=":

--- a/pykwalify/rule.py
+++ b/pykwalify/rule.py
@@ -1158,6 +1158,14 @@ class Rule(object):
                         error_key=u"mapping.regex.malformed",
                         path=path,
                     )
+
+                elif not regex[1].startswith('(') or not regex[1].endswith(')'):
+                    raise RuleError(
+                        msg=u"Regex '{0}' should start and end with parentheses".format(regex[1]),
+                        error_key=u"mapping.regex.missing_parentheses",
+                        path=path,
+                    )
+
                 else:
                     regex = regex[1]
                     try:

--- a/tests/files/success/test_mapping.yaml
+++ b/tests/files/success/test_mapping.yaml
@@ -219,7 +219,7 @@ data:
 schema:
   type: map
   mapping:
-    regex;/[A-Z]-/:
+    regex;([A-Z]-):
       type: map
       mapping:
         name:

--- a/tests/files/success/test_mapping.yaml
+++ b/tests/files/success/test_mapping.yaml
@@ -306,3 +306,15 @@ schema:
   mapping:
     regex;(person[1-9]):
       required: True
+---
+name: mapping19
+desc: Test that 'required' integer regex keys are supported.
+data:
+  1234: Albert
+  1235: Tom
+schema:
+  type: map
+  mapping:
+    regex;([0-9]+):
+      required: True
+      type: str

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -355,6 +355,9 @@ class TestCore(object):
             )
 
     def test_python_obj_loading(self, tmp_path):
+        # in latest pytest version, tmp_path is a PosixPath
+        tmp_path = str(tmp_path)
+
         schema = """
         allowempty: True
         mapping:

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -37,7 +37,7 @@ class TestRule(unittest.TestCase):
     def test_matching_rule(self):
         # Test that exception is raised when a invalid matching rule is used
         with pytest.raises(RuleError) as r:
-            Rule(schema={"type": "map", "matching-rule": "foobar", "mapping": {"regex;.+": {"type": "seq", "sequence": [{"type": "str"}]}}})
+            Rule(schema={"type": "map", "matching-rule": "foobar", "mapping": {"regex;(.+)": {"type": "seq", "sequence": [{"type": "str"}]}}})
         assert str(r.value) == "<RuleError: error code 4: Specified rule in key: foobar is not part of allowed rule set : ['any', 'all']: Path: '/'>"
         assert r.value.error_key == 'matching_rule.not_allowed'
 
@@ -349,8 +349,8 @@ class TestRule(unittest.TestCase):
 
         # This will test that a invalid regex will throw error when parsing rules
         with pytest.raises(RuleError) as r:
-            Rule(schema={"type": "map", "matching-rule": "any", "mapping": {"regex;(+": {"type": "seq", "sequence": [{"type": "str"}]}}})
-        assert str(r.value) == "<RuleError: error code 4: Unable to compile regex '(+': Path: '/'>"
+            Rule(schema={"type": "map", "matching-rule": "any", "mapping": {"regex;(+)": {"type": "seq", "sequence": [{"type": "str"}]}}})
+        assert str(r.value) == "<RuleError: error code 4: Unable to compile regex '(+)': Path: '/'>"
         assert r.value.error_key == 'mapping.regex.compile_error'
 
         # this tests map/dict but with no elements
@@ -358,6 +358,12 @@ class TestRule(unittest.TestCase):
             Rule(schema={"type": "map", "mapping": {}})
         assert str(r.value) == "<RuleError: error code 4: Mapping do not contain any elements: Path: '/'>"
         assert r.value.error_key == 'mapping.no_elements'
+
+        # Test that regex with missing parentheses are correctly detected.
+        with pytest.raises(RuleError) as r:
+            Rule(schema={"type": "map", "matching-rule": "any", "mapping": {"regex;[a-z]": {"type": "seq", "sequence": [{"type": "str"}]}}})
+            assert str(r.value) == "<RuleError: Regex '[a-z]' should start and end with parentheses: Path: '/'>"
+        assert r.value.error_key == 'mapping.regex.missing_parentheses'
 
     def test_default_value(self):
         pass


### PR DESCRIPTION
This pull request improves the way *regex* rules are handled by:
* making sure they start and end with parentheses (fixed some tests along the way)
* casting the keys to `str` before trying to match them against the regex. This unifies the way `required` parameter and key matching against the regex are handled.

I've also casted `tmp_path` fixture to `str` in 3b547fa to make the tests compatible with latest `pytest` version as it is now a `pathlib` (see https://docs.pytest.org/en/latest/tmpdir.html#the-tmp-path-fixture).