### PR TITLE
fix deprecated python core module imp to python core importlib

### DIFF
--- a/pykwalify/core.py
+++ b/pykwalify/core.py
@@ -4,7 +4,7 @@
 
 # python std lib
 import datetime
-import imp
+import importlib
 import json
 import logging
 import os
@@ -170,7 +170,7 @@ class Core(object):
             if not os.path.exists(f):
                 raise CoreError(u"Extension file: {0} not found on disk".format(f))
 
-            self.loaded_extensions.append(imp.load_source("", f))
+            self.loaded_extensions.append(importlib.load_source("", f))
 
         log.debug(self.loaded_extensions)
         log.debug([dir(m) for m in self.loaded_extensions])


### PR DESCRIPTION
<!--
	Thank you for showing interest in PyKwalify.

	Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:

<!--
	Please include a summary of the proposed changes below.
       
        imp module renamed to importlib in core.py

	Link to a Issue in the summary below
-->
#161 
