### PR TITLE
Adding Power support(ppc64le) with continuous integration/testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ sudo: false
 dist: xenial
 language: python
 cache: pip
-
+arch:
+  - amd64
+  - ppc64le
 python:
-  - "2.7"
-  - "3.5"
   - "3.6"
   - "3.7"
   - "nightly"


### PR DESCRIPTION

I am part of IBM team and working on porting power arch to packages as continuous integration & testing.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly,
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.

Pls verify and merge

<!--
	Thank you for showing interest in PyKwalify.

	Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:

<!--
	Please include a sumary of the propsed changes below.

	Link to a Issue in the summary below
-->
