### PR TITLE
moved pattern match from re match to fullmatch

### DIFF
--- a/pykwalify/core.py
+++ b/pykwalify/core.py
@@ -697,7 +697,7 @@ class Core(object):
 
             try:
                 log.debug("Matching pattern '{0}' to regex '{1}".format(rule.pattern, value))
-                res = re.match(rule.pattern, value, re.UNICODE)
+                res = re.fullmatch(rule.pattern, value, re.UNICODE)
             except TypeError:
                 res = None
 


### PR DESCRIPTION
<!--
	Thank you for showing interest in PyKwalify.

	Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:
Changing regex matching from `re.match` to `re.fullmatch`. 
To handle cases of pattern matching 
```
regex = '.*@gmail.com'
pattern1 = 'mailaddress@gmail.com' #this should match
pattern2 = 'mailaddress@gmail.comSomeOtherCharacter' # This should not match
```
<!--
	Please include a sumary of the propsed changes below.

	Link to a Issue in the summary below
-->
