### PR TITLE
Adding support for IP, IPv4 and IPv6 types

### DIFF
--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -62,6 +62,17 @@ The following types are available:
     - Validates data is a valid URL based on RFC 1808. Uses following regex
       `http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+`
 
+- **ip**
+    - Validates data is a valid IP (both IPv4 and IPv6 are accepted, see below for details)
+
+- **ipv4**
+    - Validates data is a valid IPv4 (only validates the format, not the IP range). Uses following regex
+      `^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`
+
+- **ipv6**
+    - Validates data is a valid IPv6 (only validates the format, not the IP range). Uses following regex
+      `^(?:[a-fA-F0-9]{0,4}:){0,7}[a-fA-F0-9]{0,4}$`
+
 
 Example
 

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -67,11 +67,22 @@ The following types are available:
 
 - **ipv4**
     - Validates data is a valid IPv4. Uses `IPv4Address(string)` and checks for
-      `AddressValueError, NetmaskValueError` exceptions.
+      `AddressValueError` exceptions.
 
 - **ipv6**
     - Validates data is a valid IPv6. Uses `IPv6Address(string)` and checks for
-      `AddressValueError, NetmaskValueError` exceptions.
+      `AddressValueError` exceptions.
+
+- **ip_cidr**
+    - Validates data is a valid IP network (both IPv4 and IPv6 are accepted, see below for details)
+
+- **ipv4_cidr**
+    - Validates data is a valid IPv4 network. Uses `IPv4Network(string, strict=True)` and checks for
+      `AddressValueError, NetmaskValueError, ValueError` exceptions.
+
+- **ipv6_cidr**
+    - Validates data is a valid IPv6 network. Uses `IPv6Network(string, strict=True)` and checks for
+      `AddressValueError, NetmaskValueError, ValueError` exceptions.
 
 
 Example

--- a/docs/validation-rules.rst
+++ b/docs/validation-rules.rst
@@ -66,12 +66,12 @@ The following types are available:
     - Validates data is a valid IP (both IPv4 and IPv6 are accepted, see below for details)
 
 - **ipv4**
-    - Validates data is a valid IPv4 (only validates the format, not the IP range). Uses following regex
-      `^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$`
+    - Validates data is a valid IPv4. Uses `IPv4Address(string)` and checks for
+      `AddressValueError, NetmaskValueError` exceptions.
 
 - **ipv6**
-    - Validates data is a valid IPv6 (only validates the format, not the IP range). Uses following regex
-      `^(?:[a-fA-F0-9]{0,4}:){0,7}[a-fA-F0-9]{0,4}$`
+    - Validates data is a valid IPv6. Uses `IPv6Address(string)` and checks for
+      `AddressValueError, NetmaskValueError` exceptions.
 
 
 Example

--- a/pykwalify/rule.py
+++ b/pykwalify/rule.py
@@ -20,6 +20,7 @@ from pykwalify.types import (
     sequence_aliases,
     type_class,
     is_ip,
+    is_ip_cidr
 )
 
 log = logging.getLogger(__name__)

--- a/pykwalify/rule.py
+++ b/pykwalify/rule.py
@@ -19,6 +19,7 @@ from pykwalify.types import (
     mapping_aliases,
     sequence_aliases,
     type_class,
+    is_ip,
 )
 
 log = logging.getLogger(__name__)

--- a/pykwalify/types.py
+++ b/pykwalify/types.py
@@ -38,6 +38,9 @@ _types = {
     "none": None,
     "email": str,
     "url": str,
+    "ipv4": str,
+    "ipv6": str,
+    "ip": str,
 }
 
 
@@ -151,7 +154,7 @@ def is_date(obj):
 def is_email(obj):
     """
     """
-    return re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", obj)
+    return False if not is_string(obj) else re.match(r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)", obj)
 
 
 def is_url(obj):
@@ -159,8 +162,28 @@ def is_url(obj):
     :param obj: Object that is to be validated
     :return: True/False if obj is valid 
     """
-    return re.match(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', obj)
+    return False if not is_string(obj) else re.match(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', obj)
 
+def is_ipv4(obj):
+    """
+    :param obj: Object that is to be validated
+    :return: True/False if obj is a valid IPv4 address
+    """
+    return False if not is_string(obj) else re.match(r'^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$', obj)
+
+def is_ipv6(obj):
+    """
+    :param obj: Object that is to be validated
+    :return: True/False if obj is a valid IPv6 address
+    """
+    return False if not is_string(obj) else re.match(r'^(?:[a-fA-F0-9]{0,4}:){0,7}[a-fA-F0-9]{0,4}$', obj)
+
+def is_ip(obj):
+    """
+    :param obj: Object that is to be validated
+    :return: True/False if obj is a valid IP address (both IPv4 and IPv6)
+    """
+    return is_ipv4(obj) or is_ipv6(obj)
 
 tt = {
     "str": is_string,
@@ -177,4 +200,7 @@ tt = {
     "date": is_date,
     "email": is_email,
     "url": is_url,
+    "ipv4": is_ipv4,
+    "ipv6": is_ipv6,
+    "ip": is_ip,
 }

--- a/pykwalify/types.py
+++ b/pykwalify/types.py
@@ -5,8 +5,9 @@
 # python stdlib
 import datetime
 import re
+from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network, AddressValueError, NetmaskValueError
+
 from pykwalify.compat import basestring, bytes
-from ipaddress import IPv4Address, IPv6Address, AddressValueError, NetmaskValueError
 
 DEFAULT_TYPE = "str"
 
@@ -41,8 +42,10 @@ _types = {
     "ipv4": str,
     "ipv6": str,
     "ip": str,
+    "ipv4_cidr": str,
+    "ipv6_cidr": str,
+    "ip_cidr": str
 }
-
 
 sequence_aliases = ["sequence", "seq"]
 mapping_aliases = ["map", "mapping"]
@@ -164,37 +167,40 @@ def is_url(obj):
     """
     return False if not is_string(obj) else re.match(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', obj)
 
+
 def is_ipv4(obj):
     """
     :param obj: Object that is to be validated
     :return: True/False if obj is a valid IPv4 address
     """
-    if not is_string(obj):
-        # the upaddress library will convert integers to IPs
-        # but that's not a valid case in this scenario as we don't want to consider 1 as a valid IP
+    if not isinstance(obj, basestring):
+        # the ipaddress library will convert integers to IPs
+        # but that's not a valid case in this scenario as we don't want to consider 1 as a valid IPv4
         return False
     try:
         IPv4Address(obj)
-    except (AddressValueError, NetmaskValueError):
+    except AddressValueError:
         return False
     else:
         return True
+
 
 def is_ipv6(obj):
     """
     :param obj: Object that is to be validated
     :return: True/False if obj is a valid IPv6 address
     """
-    if not is_string(obj):
-        # the upaddress library will convert integers to IPs
-        # but that's not a valid case in this scenario as we don't want to consider 1 as a valid IP
+    if not isinstance(obj, basestring):
+        # the ipaddress library will convert integers to IPs
+        # but that's not a valid case in this scenario as we don't want to consider 1 as a valid IPv6
         return False
     try:
         IPv6Address(obj)
-    except (AddressValueError, NetmaskValueError):
+    except AddressValueError:
         return False
     else:
         return True
+
 
 def is_ip(obj):
     """
@@ -202,6 +208,49 @@ def is_ip(obj):
     :return: True/False if obj is a valid IP address (both IPv4 and IPv6)
     """
     return is_ipv4(obj) or is_ipv6(obj)
+
+
+def is_ipv4_cidr(obj):
+    """
+    :param obj: Object that is to be validated
+    :return: True/False if obj is a valid IPv4 network
+    """
+    if not isinstance(obj, basestring):
+        # the ipaddress library will convert integers to IPs
+        # but that's not a valid case in this scenario as we don't want to consider 1 as a valid IPv4 network
+        return False
+    try:
+        IPv4Network(obj, strict=True)
+    except (AddressValueError, NetmaskValueError, ValueError):
+        return False
+    else:
+        return True
+
+
+def is_ipv6_cidr(obj):
+    """
+    :param obj: Object that is to be validated
+    :return: True/False if obj is a valid IPv6 network
+    """
+    if not isinstance(obj, basestring):
+        # the ipaddress library will convert integers to IPs
+        # but that's not a valid case in this scenario as we don't want to consider 1 as a valid IPv6 network
+        return False
+    try:
+        IPv6Network(obj, strict=True)
+    except (AddressValueError, NetmaskValueError, ValueError):
+        return False
+    else:
+        return True
+
+
+def is_ip_cidr(obj):
+    """
+    :param obj: Object that is to be validated
+    :return: True/False if obj is a valid IP network (both IPv4 and IPv6)
+    """
+    return is_ipv4_cidr(obj) or is_ipv6_cidr(obj)
+
 
 tt = {
     "str": is_string,
@@ -221,4 +270,7 @@ tt = {
     "ipv4": is_ipv4,
     "ipv6": is_ipv6,
     "ip": is_ip,
+    "ipv4_cidr": is_ipv4_cidr,
+    "ipv6_cidr": is_ipv6_cidr,
+    "ip_cidr": is_ip_cidr
 }

--- a/pykwalify/types.py
+++ b/pykwalify/types.py
@@ -3,10 +3,10 @@
 """ pyKwalify - types.py """
 
 # python stdlib
-import re
 import datetime
 import re
 from pykwalify.compat import basestring, bytes
+from ipaddress import IPv4Address, IPv6Address, AddressValueError, NetmaskValueError
 
 DEFAULT_TYPE = "str"
 
@@ -169,14 +169,32 @@ def is_ipv4(obj):
     :param obj: Object that is to be validated
     :return: True/False if obj is a valid IPv4 address
     """
-    return False if not is_string(obj) else re.match(r'^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$', obj)
+    if not is_string(obj):
+        # the upaddress library will convert integers to IPs
+        # but that's not a valid case in this scenario as we don't want to consider 1 as a valid IP
+        return False
+    try:
+        IPv4Address(obj)
+    except (AddressValueError, NetmaskValueError):
+        return False
+    else:
+        return True
 
 def is_ipv6(obj):
     """
     :param obj: Object that is to be validated
     :return: True/False if obj is a valid IPv6 address
     """
-    return False if not is_string(obj) else re.match(r'^(?:[a-fA-F0-9]{0,4}:){0,7}[a-fA-F0-9]{0,4}$', obj)
+    if not is_string(obj):
+        # the upaddress library will convert integers to IPs
+        # but that's not a valid case in this scenario as we don't want to consider 1 as a valid IP
+        return False
+    try:
+        IPv6Address(obj)
+    except (AddressValueError, NetmaskValueError):
+        return False
+    else:
+        return True
 
 def is_ip(obj):
     """

--- a/tests/files/fail/test_type_ip.yaml
+++ b/tests/files/fail/test_type_ip.yaml
@@ -1,0 +1,11 @@
+---
+name:  ip-fail
+desc:  basic ip type validation. Fails as not IPv4 or V6
+#
+schema:
+  type: ip
+#
+data:
+  "foo"
+errors:
+   - "Value 'foo' is not of type 'ip'. Path: ''"

--- a/tests/files/fail/test_type_ip_cidr.yaml
+++ b/tests/files/fail/test_type_ip_cidr.yaml
@@ -1,0 +1,11 @@
+---
+name:  ip-cidr-fail
+desc:  basic ip network type validation. Fails as not IPv4 or V6 network
+#
+schema:
+  type: ip_cidr
+#
+data:
+  "foo"
+errors:
+   - "Value 'foo' is not of type 'ip'. Path: ''"

--- a/tests/files/fail/test_type_ipv4.yaml
+++ b/tests/files/fail/test_type_ipv4.yaml
@@ -1,0 +1,15 @@
+---
+name:  ipv4-fail
+desc:  basic ip type validation. Fails as not IPv4
+#
+schema:
+  type: seq
+  sequence:
+    - type: ipv4
+#
+data:
+  - "foo"
+  - "2001:db8:3333:4444:5555:6666:7777:8888"
+errors:
+   - "Value 'foo' is not of type 'ipv4'. Path: '/0'"
+   - "Value '2001:db8:3333:4444:5555:6666:7777:8888' is not of type 'ipv4'. Path: '/1'"

--- a/tests/files/fail/test_type_ipv4.yaml
+++ b/tests/files/fail/test_type_ipv4.yaml
@@ -9,7 +9,13 @@ schema:
 #
 data:
   - "foo"
+  - 1
+  - "127.0.1.0/24"
+  - "256.256.256.256"
   - "2001:db8:3333:4444:5555:6666:7777:8888"
 errors:
    - "Value 'foo' is not of type 'ipv4'. Path: '/0'"
-   - "Value '2001:db8:3333:4444:5555:6666:7777:8888' is not of type 'ipv4'. Path: '/1'"
+   - "Value '1' is not of type 'ipv4'. Path: '/1'"
+   - "Value '127.0.1.0/24' is not of type 'ipv4'. Path: '/2'"
+   - "Value '256.256.256.256' is not of type 'ipv4'. Path: '/3'"
+   - "Value '2001:db8:3333:4444:5555:6666:7777:8888' is not of type 'ipv4'. Path: '/4'"

--- a/tests/files/fail/test_type_ipv4_cidr.yaml
+++ b/tests/files/fail/test_type_ipv4_cidr.yaml
@@ -1,0 +1,21 @@
+---
+name:  ipv4-cidr-fail
+desc:  basic ip network type validation. Fails as not IPv4 network
+#
+schema:
+  type: seq
+  sequence:
+    - type: ipv4_cidr
+#
+data:
+  - "foo"
+  - 1
+  - "127.0.1.1/24"
+  - "256.256.256.0/24"
+  - "2001:db8::/32"
+errors:
+   - "Value 'foo' is not of type 'ipv4_cidr'. Path: '/0'"
+   - "Value '1' is not of type 'ipv4_cidr'. Path: '/1'"
+   - "Value '127.0.1.1/24' is not of type 'ipv4_cidr'. Path: '/2'"
+   - "Value '256.256.256.0/24' is not of type 'ipv4_cidr'. Path: '/3'"
+   - "Value '2001:db8::/32' is not of type 'ipv4_cidr'. Path: '/4'"

--- a/tests/files/fail/test_type_ipv6.yaml
+++ b/tests/files/fail/test_type_ipv6.yaml
@@ -1,0 +1,15 @@
+---
+name:  ipv6-fail
+desc:  basic ip type validation. Fails as not IPv6
+#
+schema:
+  type: seq
+  sequence:
+    - type: ipv6
+#
+data:
+  - "foo"
+  - "8.8.8.8"
+errors:
+   - "Value 'foo' is not of type 'ipv6'. Path: '/0'"
+   - "Value '8.8.8.8' is not of type 'ipv6'. Path: '/1'"

--- a/tests/files/fail/test_type_ipv6.yaml
+++ b/tests/files/fail/test_type_ipv6.yaml
@@ -9,7 +9,11 @@ schema:
 #
 data:
   - "foo"
+  - 1
+  - "2001:db8::/32"
   - "8.8.8.8"
 errors:
    - "Value 'foo' is not of type 'ipv6'. Path: '/0'"
-   - "Value '8.8.8.8' is not of type 'ipv6'. Path: '/1'"
+   - "Value '1' is not of type 'ipv6'. Path: '/1'"
+   - "Value '2001:db8::/32' is not of type 'ipv6'. Path: '/2'"
+   - "Value '8.8.8.8' is not of type 'ipv6'. Path: '/3'"

--- a/tests/files/fail/test_type_ipv6_cidr.yaml
+++ b/tests/files/fail/test_type_ipv6_cidr.yaml
@@ -1,0 +1,19 @@
+---
+name:  ipv6-cidr-fail
+desc:  basic ip network type validation. Fails as not IPv6 network
+#
+schema:
+  type: seq
+  sequence:
+    - type: ipv6_cidr
+#
+data:
+  - "foo"
+  - 1
+  - "127.0.1.0/24"
+  - "2001:db8::1/32"
+errors:
+   - "Value 'foo' is not of type 'ipv6_cidr'. Path: '/0'"
+   - "Value '1' is not of type 'ipv6_cidr'. Path: '/1'"
+   - "Value '127.0.1.0/24' is not of type 'ipv6_cidr'. Path: '/2'"
+   - "Value '2001:db8::1/32' is not of type 'ipv6_cidr'. Path: '/3'"

--- a/tests/files/success/test_type_ip.yaml
+++ b/tests/files/success/test_type_ip.yaml
@@ -3,7 +3,11 @@ name:  ip-success
 desc:  basic ip type validation
 #
 schema:
-  type: ip
+  type: seq
+  sequence:
+    - type: ip
+
 #
 data:
-  "8.8.8.8"
+  - "8.8.8.8"
+  - "2001:4860:4860::8888"

--- a/tests/files/success/test_type_ip.yaml
+++ b/tests/files/success/test_type_ip.yaml
@@ -1,0 +1,9 @@
+---
+name:  ip-success
+desc:  basic ip type validation
+#
+schema:
+  type: ip
+#
+data:
+  "8.8.8.8"

--- a/tests/files/success/test_type_ip_cidr.yaml
+++ b/tests/files/success/test_type_ip_cidr.yaml
@@ -1,0 +1,14 @@
+---
+name:  ip-cidr-success
+desc:  basic ip network type validation
+#
+schema:
+  type: seq
+  sequence:
+    - type: ip_cidr
+
+#
+data:
+  - "192.168.0.0/24"
+  - "2001:db8::/32"
+  - "2001:db8::0/32"

--- a/tests/files/success/test_type_ipv4.yaml
+++ b/tests/files/success/test_type_ipv4.yaml
@@ -1,0 +1,9 @@
+---
+name:  ipv4-success
+desc:  basic ip type validation
+#
+schema:
+  type: ipv4
+#
+data:
+  "8.8.8.8"

--- a/tests/files/success/test_type_ipv4_cidr.yaml
+++ b/tests/files/success/test_type_ipv4_cidr.yaml
@@ -1,0 +1,9 @@
+---
+name:  ipv4-cidr-success
+desc:  basic ip network type validation
+#
+schema:
+  type: ipv4_cidr
+#
+data:
+  "192.168.0.0/24"

--- a/tests/files/success/test_type_ipv6.yaml
+++ b/tests/files/success/test_type_ipv6.yaml
@@ -1,0 +1,14 @@
+---
+name:  ipv6-success
+desc:  basic ipv6 type validation
+#
+schema:
+  type: seq
+  sequence:
+    - type: ipv6
+
+#
+data:
+  - "2001:db8:3333:4444:5555:6666:7777:8888"
+  - "::1234:5678"
+  - "::"

--- a/tests/files/success/test_type_ipv6_cidr.yaml
+++ b/tests/files/success/test_type_ipv6_cidr.yaml
@@ -1,0 +1,14 @@
+---
+name:  ipv6-cidr-success
+desc:  basic ipv6 network type validation
+#
+schema:
+  type: seq
+  sequence:
+    - type: ipv6_cidr
+
+#
+data:
+  - "2001:db8::/32"
+  - "2001:db8::0/32"
+  - "2001:0db8:0000:0000:0000:0000:0000:0000/32"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -473,6 +473,10 @@ class TestCore(object):
             "test_type_ip.yaml",
             "test_type_ipv4.yaml",
             "test_type_ipv6.yaml",
+            # All tests for TYPE: ip_cidr
+            "test_type_ip_cidr.yaml",
+            "test_type_ipv4_cidr.yaml",
+            "test_type_ipv6_cidr.yaml",
         ]
 
         _fail_tests = [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -469,6 +469,10 @@ class TestCore(object):
             "test_type_email.yaml",
             # All tests for TYPE: url
             "test_type_url.yaml",
+            # All tests for TYPE: ip
+            "test_type_ip.yaml",
+            "test_type_ipv4.yaml",
+            "test_type_ipv6.yaml",
         ]
 
         _fail_tests = [
@@ -554,6 +558,10 @@ class TestCore(object):
             ("test_type_email.yaml", SchemaError),
             # All tests for TYPE: url
             ("test_type_url.yaml", SchemaError),
+            # All tests for TYPE: ip
+            ("test_type_ip.yaml", SchemaError),
+            ("test_type_ipv4.yaml", SchemaError),
+            ("test_type_ipv6.yaml", SchemaError),
         ]
 
         # Add override magic to make it easier to test a specific file

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -82,11 +82,35 @@ class TestTypes(unittest.TestCase):
         assert not types.is_email(None)
 
         assert types.is_ipv4("8.8.8.8")
+        assert not types.is_ipv4("127.0.1.0/24")
+        assert not types.is_ipv4("256.256.256.256")
+        assert not types.is_ipv4("2001:db8:3333:4444:5555:6666:7777:8888")
+
         assert types.is_ipv6("2001:db8:3333:4444:5555:6666:7777:8888")
         assert types.is_ipv6("::1234:5678")
         assert types.is_ipv6("::")
+        assert not types.is_ipv6("2001:db8::/32")
+        assert not types.is_ipv6("8.8.8.8")
+
         assert types.is_ip("8.8.8.8")
-        assert types.is_ip("2001:db8:3333:4444:5555:6666:7777:8888")
+        assert types.is_ip("2001:4860:4860::8888")
         assert not types.is_ip("foo")
-        assert not types.is_ip(None)
         assert not types.is_ip(1)
+        assert not types.is_ip(None)
+
+        assert types.is_ipv4_cidr("192.168.0.0/24")
+        assert not types.is_ipv4_cidr("127.0.1.1/24")
+        assert not types.is_ipv4_cidr("256.256.256.0/24")
+        assert not types.is_ipv4_cidr("2001:db8::/32")
+
+        assert types.is_ipv6_cidr("2001:db8::/32")
+        assert types.is_ipv6_cidr("2001:db8::0/32")
+        assert types.is_ipv6_cidr("2001:0db8:0000:0000:0000:0000:0000:0000/32")
+        assert not types.is_ipv6_cidr("127.0.1.0/24")
+        assert not types.is_ipv6_cidr("2001:db8::1/32")
+
+        assert types.is_ip_cidr("192.168.0.0/24")
+        assert types.is_ip_cidr("2001:db8::/32")
+        assert not types.is_ip_cidr("foo")
+        assert not types.is_ip_cidr(1)
+        assert not types.is_ip_cidr(None)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -75,3 +75,18 @@ class TestTypes(unittest.TestCase):
         assert not types.is_none("foo")
 
         assert types.is_url("https://github.com")
+        assert not types.is_url(None)
+
+        assert types.is_email("foo@bar.com")
+        assert not types.is_email("foo")
+        assert not types.is_email(None)
+
+        assert types.is_ipv4("8.8.8.8")
+        assert types.is_ipv6("2001:db8:3333:4444:5555:6666:7777:8888")
+        assert types.is_ipv6("::1234:5678")
+        assert types.is_ipv6("::")
+        assert types.is_ip("8.8.8.8")
+        assert types.is_ip("2001:db8:3333:4444:5555:6666:7777:8888")
+        assert not types.is_ip("foo")
+        assert not types.is_ip(None)
+        assert not types.is_ip(1)


### PR DESCRIPTION
Adds support to validate IP, IPv4 and IPv6 to the basic types.

Now this `schema.yaml` would be supported:

```
type: map
mapping:
  first_ip:
    type: ip
  second_ip:
    type: ipv4
  third_ip:
    type: ipv6
```
and will validate:
```
first_ip: 8.8.8.8
second_ip: 8.8.8.8
third_ip: 2001:db8:3333:4444:5555:6666:7777:8888
```
