### PR TITLE
Fix error message for min and min-ex violations

### DIFF
--- a/pykwalify/core.py
+++ b/pykwalify/core.py
@@ -889,7 +889,7 @@ class Core(object):
 
         if min_ is not None and min_ > value_length:
             self.errors.append(SchemaError.SchemaErrorEntry(
-                msg=u"Value: '{value_str}' has length of '{value}', greater than min limit '{min_}'. Path: '{path}'",
+                msg=u"Value: '{value_str}' has length of '{value}', less than min limit '{min_}'. Path: '{path}'",
                 value_str=value,
                 path=path,
                 value=len(value),
@@ -898,7 +898,7 @@ class Core(object):
 
         if max_ex is not None and max_ex <= value_length:
             self.errors.append(SchemaError.SchemaErrorEntry(
-                msg=u"Value: '{value_str}' has length of '{value}', greater than max_ex limit '{max_ex}'. Path: '{path}'",
+                msg=u"Value: '{value_str}' has length of '{value}', greater than or equal to max_ex limit '{max_ex}'. Path: '{path}'",
                 value_str=value,
                 path=path,
                 value=len(value),
@@ -907,7 +907,7 @@ class Core(object):
 
         if min_ex is not None and min_ex >= value_length:
             self.errors.append(SchemaError.SchemaErrorEntry(
-                msg=u"Value: '{value_str}' has length of '{value}', greater than min_ex limit '{min_ex}'. Path: '{path}'",
+                msg=u"Value: '{value_str}' has length of '{value}', less than or equal to min_ex limit '{min_ex}'. Path: '{path}'",
                 value_str=value,
                 path=path,
                 value=len(value),


### PR DESCRIPTION
The errors are actually that a value is smaller than `min` or `min-ex`.

<!--
	Thank you for showing interest in PyKwalify.

	Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:

- Changes error message to "less than"/"less than or equal to" instead of "greater than" for `min` and `min-ex` violations.
- Changes error message to "greater than or equal to" instead of just "greater than" for `max-ex` violations.

- Fixes #194
<!--
	Please include a sumary of the propsed changes below.

	Link to a Issue in the summary below
-->
