### PR TITLE
Fixing tests for ruamel yaml 0.18+

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,7 +12,7 @@ from pykwalify.errors import SchemaError, CoreError
 
 # 3rd party imports
 import pytest
-from pykwalify.compat import yaml
+from pykwalify.compat import yml
 from testfixtures import compare
 
 
@@ -579,7 +579,7 @@ class TestCore(object):
         for passing_test_file in pass_tests:
             f = self.f(os.path.join("success", passing_test_file))
             with open(f, "r") as stream:
-                yaml_data = yaml.safe_load_all(stream)
+                yaml_data = yml.load_all(stream)
 
                 for document_index, document in enumerate(yaml_data):
                     data = document["data"]
@@ -600,7 +600,7 @@ class TestCore(object):
         for failing_test, exception_type in _fail_tests:
             f = self.f(os.path.join("fail", failing_test))
             with open(f, "r") as stream:
-                yaml_data = yaml.safe_load_all(stream)
+                yaml_data = yml.load_all(stream)
 
                 for document_index, document in enumerate(yaml_data):
                     data = document["data"]

--- a/tests/test_unicode.py
+++ b/tests/test_unicode.py
@@ -12,7 +12,7 @@ from pykwalify.core import Core
 from pykwalify.errors import SchemaError
 
 # 3rd party imports
-from pykwalify.compat import yaml
+from pykwalify.compat import yml
 from testfixtures import compare
 
 
@@ -47,7 +47,8 @@ class TestUnicode(object):
         }
 
         source_f = tmpdir.join(u"2så.json")
-        source_f.write(yaml.safe_dump(fail_data_2s_yaml, allow_unicode=True))
+        with source_f.open('w') as stream:
+            yml.dump(fail_data_2s_yaml, stream)
 
         _pass_tests = [
             # Test mapping with unicode key and value
@@ -65,7 +66,7 @@ class TestUnicode(object):
             f = self.f(passing_test_files)
 
             with open(f, "r") as stream:
-                yaml_data = yaml.safe_load(stream)
+                yaml_data = yml.load(stream)
                 data = yaml_data["data"]
                 schema = yaml_data["schema"]
 
@@ -102,7 +103,8 @@ class TestUnicode(object):
         }
 
         source_f = tmpdir.join(u"2få.json")
-        source_f.write(yaml.safe_dump(fail_data_2f_yaml, allow_unicode=True))
+        with source_f.open('w') as stream:
+            yml.dump(fail_data_2f_yaml, stream)
 
         _fail_tests = [
             # Test mapping with unicode key and value but wrong type
@@ -120,7 +122,7 @@ class TestUnicode(object):
             f = self.f(failing_test)
 
             with open(f, "r") as stream:
-                yaml_data = yaml.safe_load(stream)
+                yaml_data = yml.load(stream)
                 data = yaml_data["data"]
                 schema = yaml_data["schema"]
                 errors = yaml_data["errors"]


### PR DESCRIPTION
<!--
	Thank you for showing interest in PyKwalify.

	Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #198

<!--
	Please include a sumary of the propsed changes below.

	Link to a Issue in the summary below
-->

ruamel.yaml 0.18.0 removed deprecated API methods like `safe_dump`, `safe_load_all`, and usage of `dump` without a `stream` argument. This PR updates the usage by utilizing the `yml` object in `pykwalify.compat` for equivalent safe API methods